### PR TITLE
fix: resolve EStructuralFeature paths in fragment resolution

### DIFF
--- a/src/json/JSONLoad.ts
+++ b/src/json/JSONLoad.ts
@@ -19,6 +19,7 @@ import { Resource } from '../Resource.js';
 import { URI } from '../URI.js';
 import { isEList } from '../EList.js';
 import { EProxyImpl } from '../runtime/EProxyImpl.js';
+import { resolveClassifierInPackage } from '../runtime/resolveClassifierInPackage.js';
 
 /**
  * Forward reference to be resolved after loading.
@@ -383,9 +384,45 @@ export class JSONLoad {
       return ePackage as unknown as EObject;
     }
 
-    const classifierName = path.split('/')[0];
-    const classifier = ePackage.getEClassifier(classifierName);
-    return classifier as unknown as EObject || null;
+    const segments = path.split('/');
+
+    // Try resolving as subpackage path first
+    const classifier = resolveClassifierInPackage(ePackage, path);
+    if (classifier) {
+      return classifier as unknown as EObject;
+    }
+
+    // If that failed and we have 2+ segments, try ClassName/featureName pattern:
+    // Navigate subpackages for all but last 2 segments, then resolve classifier + feature
+    if (segments.length >= 2) {
+      let currentPkg: EPackage = ePackage;
+
+      // Navigate subpackages (all segments except last two)
+      for (let i = 0; i < segments.length - 2; i++) {
+        const subPackages = currentPkg.getESubpackages();
+        let found: EPackage | null = null;
+        for (let j = 0; j < subPackages.length; j++) {
+          if (subPackages.get(j).getName() === segments[i]) {
+            found = subPackages.get(j);
+            break;
+          }
+        }
+        if (!found) return null;
+        currentPkg = found;
+      }
+
+      // Second-to-last segment: classifier
+      const classifierName = segments[segments.length - 2];
+      const eClassifier = currentPkg.getEClassifier(classifierName);
+      if (eClassifier && 'getEStructuralFeature' in eClassifier) {
+        const feature = (eClassifier as EClass).getEStructuralFeature(segments[segments.length - 1]);
+        if (feature) {
+          return feature as unknown as EObject;
+        }
+      }
+    }
+
+    return null;
   }
 
   /**

--- a/src/runtime/BasicResourceSet.ts
+++ b/src/runtime/BasicResourceSet.ts
@@ -13,6 +13,8 @@ import { EObject } from '../EObject.js';
 import { EPackage, EPackageRegistry } from '../EPackage.js';
 import { BasicResource } from './BasicResource.js';
 import { EList, BasicEList, createIndexedProxy } from '../EList.js';
+import { EClass } from '../EClass.js';
+import { resolveClassifierInPackage } from './resolveClassifierInPackage.js';
 
 /**
  * Basic ResourceSet implementation
@@ -471,14 +473,41 @@ class SyntheticPackageResource implements Resource {
       return this._syntheticPackage as unknown as EObject;
     }
 
-    // Split by / for nested paths
     const segments = path.split('/');
-    const classifierName = segments[0];
 
-    // Find classifier by name
-    const classifier = this._syntheticPackage.getEClassifier(classifierName);
+    // Try resolving as subpackage path first (handles single segment and subpackage navigation)
+    const classifier = resolveClassifierInPackage(this._syntheticPackage, path);
     if (classifier) {
       return classifier as unknown as EObject;
+    }
+
+    // If that failed and we have 2+ segments, try ClassName/featureName pattern
+    if (segments.length >= 2) {
+      let currentPkg: EPackage = this._syntheticPackage;
+
+      // Navigate subpackages (all segments except last two)
+      for (let i = 0; i < segments.length - 2; i++) {
+        const subPackages = currentPkg.getESubpackages();
+        let found: EPackage | null = null;
+        for (let j = 0; j < subPackages.length; j++) {
+          if (subPackages.get(j).getName() === segments[i]) {
+            found = subPackages.get(j);
+            break;
+          }
+        }
+        if (!found) return null;
+        currentPkg = found;
+      }
+
+      // Second-to-last segment: classifier, last segment: structural feature
+      const classifierName = segments[segments.length - 2];
+      const eClassifier = currentPkg.getEClassifier(classifierName);
+      if (eClassifier && 'getEStructuralFeature' in eClassifier) {
+        const feature = (eClassifier as EClass).getEStructuralFeature(segments[segments.length - 1]);
+        if (feature) {
+          return feature as unknown as EObject;
+        }
+      }
     }
 
     return null;

--- a/src/xmi/XMLHandler.ts
+++ b/src/xmi/XMLHandler.ts
@@ -873,8 +873,45 @@ export class XMLHandler {
       return ePackage as unknown as EObject;
     }
 
+    const segments = path.split('/');
+
+    // Try resolving as subpackage path first (existing behavior)
     const classifier = resolveClassifierInPackage(ePackage, path);
-    return classifier as unknown as EObject ?? null;
+    if (classifier) {
+      return classifier as unknown as EObject;
+    }
+
+    // If that failed and we have 2+ segments, try ClassName/featureName pattern:
+    // Navigate subpackages for all but last 2 segments, then resolve classifier + feature
+    if (segments.length >= 2) {
+      let currentPkg: EPackage = ePackage;
+
+      // Navigate subpackages (all segments except last two)
+      for (let i = 0; i < segments.length - 2; i++) {
+        const subPackages = currentPkg.getESubpackages();
+        let found: EPackage | null = null;
+        for (let j = 0; j < subPackages.length; j++) {
+          if (subPackages.get(j).getName() === segments[i]) {
+            found = subPackages.get(j);
+            break;
+          }
+        }
+        if (!found) return null;
+        currentPkg = found;
+      }
+
+      // Second-to-last segment: classifier
+      const classifierName = segments[segments.length - 2];
+      const eClassifier = currentPkg.getEClassifier(classifierName);
+      if (eClassifier && 'getEStructuralFeature' in eClassifier) {
+        const feature = (eClassifier as EClass).getEStructuralFeature(segments[segments.length - 1]);
+        if (feature) {
+          return feature as unknown as EObject;
+        }
+      }
+    }
+
+    return null;
   }
 
   /**

--- a/tests/ExternalReference.test.ts
+++ b/tests/ExternalReference.test.ts
@@ -75,4 +75,30 @@ describe('External Reference Resolution', () => {
     expect(resolved).not.toBeNull();
     expect((resolved as any).getName()).toBe('EInt');
   });
+
+  it('should resolve EStructuralFeature via //ClassName/featureName fragment', () => {
+    const ecorePackage = getEcorePackage();
+    const resourceSet = new BasicResourceSet();
+    resourceSet.getPackageRegistry().set(ECORE_NS_URI, ecorePackage);
+
+    // Resolve EClass.abstract via fragment //EClass/abstract
+    const uri = URI.createURI(ECORE_NS_URI + '#//EClass/abstract');
+    const resolved = resourceSet.getEObject(uri, true);
+
+    expect(resolved).not.toBeNull();
+    expect((resolved as any).getName()).toBe('abstract');
+  });
+
+  it('should resolve EStructuralFeature reference in XMI', () => {
+    const ecorePackage = getEcorePackage();
+    const resourceSet = new BasicResourceSet();
+    resourceSet.getPackageRegistry().set(ECORE_NS_URI, ecorePackage);
+
+    // Resolve EClass.eSuperTypes
+    const uri = URI.createURI(ECORE_NS_URI + '#//EClass/eSuperTypes');
+    const resolved = resourceSet.getEObject(uri, true);
+
+    expect(resolved).not.toBeNull();
+    expect((resolved as any).getName()).toBe('eSuperTypes');
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #22

- `resolveFragmentInPackage` could not resolve fragment paths like `//ClassName/featureName` — multi-segment paths were only interpreted as subpackage navigation
- The fix tries classifier+feature resolution when subpackage lookup fails, matching Java EMF's segment-by-segment `eObjectForURIFragmentSegment` behavior
- Fixed in all three affected locations: `XMLHandler`, `JSONLoad`, and `SyntheticPackageResource`

## Test plan

- [x] Added tests resolving `//EClass/abstract` and `//EClass/eSuperTypes` via registered EcorePackage
- [x] All 300 tests pass (298 existing + 2 new)