### PR TITLE
fix: serialize intra-document non-containment refs as attributes (#27)

### DIFF
--- a/src/xmi/XMLSave.ts
+++ b/src/xmi/XMLSave.ts
@@ -256,12 +256,12 @@ export class XMLSave {
         if (!ref.isContainment()) {
           let value = obj.eGet(ref);
           if (value !== null && value !== undefined) {
+            const serializedRefName = this.helper.getSerializedFeatureName(ref);
             if (!feature.isMany()) {
               // Single-valued reference - resolve proxy first
               value = this.resolveValue(value, obj);
 
               if (value !== null && value !== undefined) {
-                const serializedRefName = this.helper.getSerializedFeatureName(ref);
                 // If value is now a string (unresolved proxy URI), use it directly
                 if (typeof value === 'string') {
                   this.output.push(` ${serializedRefName}="${this.escapeXml(value)}"`);
@@ -278,8 +278,24 @@ export class XMLSave {
                   }
                 }
               }
+            } else if (Array.isArray(value) || isEList(value)) {
+              // Multi-valued non-containment refs: same-document refs as space-separated attribute
+              const sameDocHrefs: string[] = [];
+              for (const refObj of value) {
+                const resolved = this.resolveValue(refObj, obj);
+                if (resolved === null || resolved === undefined) continue;
+                if (typeof resolved === 'string') continue; // cross-doc proxy, handled in writeElements
+                const refResource = (resolved as EObject).eResource?.();
+                if (refResource && refResource === this.resource) {
+                  const href = this.getHref(resolved as EObject);
+                  if (href) sameDocHrefs.push(href);
+                }
+                // cross-document refs are handled in writeElements
+              }
+              if (sameDocHrefs.length > 0) {
+                this.output.push(` ${serializedRefName}="${this.escapeXml(sameDocHrefs.join(' '))}"`);
+              }
             }
-            // Multi-valued non-containment refs are written as elements with href
           }
         }
       }
@@ -381,8 +397,13 @@ export class XMLSave {
           if ((Array.isArray(value) || isEList(value)) && value.length > 0) return true;
           if (!Array.isArray(value) && !isEList(value)) return true;
         } else if (feature.isMany() && (Array.isArray(value) || isEList(value)) && value.length > 0) {
-          // Multi-valued non-containment references
-          return true;
+          // Multi-valued non-containment references: only element content if cross-document
+          for (const refObj of value) {
+            const refResource = (refObj as EObject).eResource?.();
+            if (!refResource || refResource !== this.resource) {
+              return true;
+            }
+          }
         }
       }
     }
@@ -414,9 +435,14 @@ export class XMLSave {
             this.writeElement(ref, value as EObject);
           }
         } else if (feature.isMany() && (Array.isArray(value) || isEList(value)) && value.length > 0) {
-          // Multi-valued non-containment: write as elements with href
+          // Multi-valued non-containment: only cross-document refs as elements with href
           for (const refObj of value) {
-            const href = this.getHref(refObj as EObject);
+            const resolved = this.resolveValue(refObj, obj);
+            if (resolved === null || resolved === undefined) continue;
+            const refResource = typeof resolved !== 'string' ? (resolved as EObject).eResource?.() : null;
+            // Skip same-document refs (already written as attribute)
+            if (refResource && refResource === this.resource) continue;
+            const href = typeof resolved === 'string' ? resolved : this.getHref(resolved as EObject);
             if (href) {
               this.writeIndent();
               this.output.push(`<${this.helper.getSerializedFeatureName(ref)} href="${this.escapeXml(href)}"/>\n`);

--- a/tests/Persistence.test.ts
+++ b/tests/Persistence.test.ts
@@ -230,8 +230,8 @@ describe('Persistence', () => {
       expect(xml).toContain('brand="vw"');
       // Should have containment for cars
       expect(xml).toContain('<cars');
-      // Should have reference for children (multi-valued as element with href)
-      expect(xml).toContain('<children href=');
+      // Should have reference for children (multi-valued, same-document as attribute)
+      expect(xml).toContain('children=');
     });
 
     /**
@@ -456,8 +456,8 @@ describe('Persistence', () => {
       console.log('Bidirectional XML:', xml);
 
       // Both sides of the relationship should be serialized
-      // children is multi-valued -> element with href
-      expect(xml).toContain('<children href=');
+      // children is multi-valued, same-document -> attribute
+      expect(xml).toContain('children=');
       // father is single-valued -> attribute
       expect(xml).toContain('father=');
     });

--- a/tests/XMISave.test.ts
+++ b/tests/XMISave.test.ts
@@ -782,6 +782,47 @@ describe('XMI Serialization', () => {
       expect(xml).toMatch(/primaryAddress="\/[^"]+"/);
     });
 
+    it('should serialize multi-valued non-containment refs as attribute for same-document targets', () => {
+      // Add a multi-valued non-containment reference: Person.friends (many, non-containment)
+      const friendsRef = new BasicEReference();
+      friendsRef.setName('friends');
+      friendsRef.setEType(personClass);
+      friendsRef.setContainment(false);
+      friendsRef.setUpperBound(-1);
+      personClass.getEStructuralFeatures().push(friendsRef);
+
+      const resource = new XMIResource(URI.createURI('test://multi-ref-many.xmi'));
+      resource.setResourceSet(resourceSet);
+
+      const factory = testPackage.getEFactoryInstance();
+
+      const person1 = factory.create(personClass);
+      person1.eSet(personClass.getEStructuralFeature('name')!, 'Alice');
+
+      const person2 = factory.create(personClass);
+      person2.eSet(personClass.getEStructuralFeature('name')!, 'Bob');
+
+      const person3 = factory.create(personClass);
+      person3.eSet(personClass.getEStructuralFeature('name')!, 'Charlie');
+
+      // All three are root objects in the same resource
+      resource.getContents().push(person1);
+      resource.getContents().push(person2);
+      resource.getContents().push(person3);
+
+      // person1.friends = [person2, person3] (multi-valued non-containment, same document)
+      const friendsList = person1.eGet(personClass.getEStructuralFeature('friends')!) as EObject[];
+      friendsList.push(person2);
+      friendsList.push(person3);
+
+      const xml = resource.saveToString();
+      console.log('Multi-valued non-containment same-doc XML:', xml);
+
+      // Should be serialized as attribute with space-separated fragments, NOT as child elements with href
+      expect(xml).toContain('friends="/1 /2"');
+      expect(xml).not.toContain('<friends href=');
+    });
+
     it('should collect namespaces from all root objects', () => {
       // Create a second package
       const otherPackage = new BasicEPackage();


### PR DESCRIPTION
Multi-valued non-containment references to objects in the same resource are now serialized as space-separated attribute values instead of child elements with href, matching Java EMF behavior.

Closes #27