### PR TITLE
Correct README: @emfts/core is a full implementation, not interfaces-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # EMFTS - Eclipse Modeling Framework for TypeScript
 
-TypeScript interfaces converted from Eclipse EMF Core.
+A TypeScript implementation of Eclipse EMF Core — interfaces *and* runtime.
 
 ## Overview
 
-This package provides TypeScript interface definitions for the Eclipse Modeling Framework (EMF) Core metamodel. These interfaces enable type-safe modeling in TypeScript/JavaScript environments.
+This package provides a TypeScript implementation of the Eclipse Modeling Framework (EMF) Core metamodel — both the interface definitions and a working runtime: dynamic model objects with a reflective API, factories, the package registry, change notification, and JSON/XMI persistence. It enables type-safe modeling in TypeScript/JavaScript environments.
 
 The Ecore metamodel aligns with the OMG [Meta Object Facility (MOF)](https://www.omg.org/spec/MOF/) — specifically EMOF (Essential MOF).
 
@@ -109,6 +109,6 @@ These interfaces are TypeScript conversions of:
 
 ## Notes
 
-- This is a pure interface package - no implementations included
+- Ships interfaces and their runtime implementations (dynamic EObjects, EList/EMap, factories, registry, notifications, JSON/XMI resources)
 - Designed for building EMF-compatible tools in TypeScript
 - Suitable for code generators, model validators, and runtime frameworks


### PR DESCRIPTION
The README claimed *"a pure interface package - no implementations included"*. That is inaccurate — `@emfts/core` ships a working runtime (dynamic EObjects with reflective API, EList/EMap, factories, package registry, change notification, JSON/XMI persistence), covered by 299 tests. Updates the intro, overview and notes to reflect this. Docs only.