### PR TITLE
fix: XMI Save non-containment reference serialization

### DIFF
--- a/src/ecore/EcoreValidator.ts
+++ b/src/ecore/EcoreValidator.ts
@@ -1,0 +1,212 @@
+/**
+ * Copyright (c) 2024-2025 Data In Motion Consulting GmbH, Stadt Jena, Software Hochstein GmbH
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+import { EObject } from '../EObject.js';
+import { EClass } from '../EClass.js';
+import { EPackage } from '../EPackage.js';
+import { EReference } from '../EReference.js';
+import { EStructuralFeature } from '../EStructuralFeature.js';
+import { EValidator } from '../util/EValidator.js';
+import { BasicDiagnostic, DiagnosticSeverity } from '../util/Diagnostic.js';
+
+const SOURCE = 'org.eclipse.emf.ecore';
+
+function error(diagnostic: BasicDiagnostic, message: string, data: EObject[]): void {
+  diagnostic.add(new BasicDiagnostic(DiagnosticSeverity.ERROR, SOURCE, message, data));
+}
+
+function warning(diagnostic: BasicDiagnostic, message: string, data: EObject[]): void {
+  diagnostic.add(new BasicDiagnostic(DiagnosticSeverity.WARNING, SOURCE, message, data));
+}
+
+export class EcoreValidator implements EValidator {
+  validate(eObject: EObject, diagnostic: BasicDiagnostic): boolean {
+    const eClass = eObject.eClass();
+    if (!eClass) return true;
+
+    const className = eClass.getName();
+
+    switch (className) {
+      case 'EClass':
+        return this.validateEClass(eObject, diagnostic);
+      case 'EPackage':
+        return this.validateEPackage(eObject, diagnostic);
+      case 'EReference':
+        return this.validateEReference(eObject, diagnostic);
+      case 'EAttribute':
+        return this.validateEStructuralFeature(eObject, diagnostic);
+      default:
+        return true;
+    }
+  }
+
+  private validateEClass(obj: EObject, diagnostic: BasicDiagnostic): boolean {
+    const eClass = obj as unknown as EClass;
+    let valid = true;
+
+    // UniqueFeatureNames
+    const featureNames = new Map<string, EStructuralFeature>();
+    for (const feature of eClass.getEStructuralFeatures()) {
+      const name = feature.getName?.();
+      if (name) {
+        const existing = featureNames.get(name);
+        if (existing) {
+          error(diagnostic,
+            `The feature '${name}' is not unique in class '${eClass.getName()}'`,
+            [obj]);
+          valid = false;
+        } else {
+          featureNames.set(name, feature);
+        }
+      }
+    }
+
+    // NoCircularSuperTypes
+    if (this.hasCircularSuperTypes(eClass)) {
+      error(diagnostic,
+        `The class '${eClass.getName()}' has a circular inheritance hierarchy`,
+        [obj]);
+      valid = false;
+    }
+
+    return valid;
+  }
+
+  private hasCircularSuperTypes(eClass: EClass): boolean {
+    const visited = new Set<EClass>();
+    const stack: EClass[] = [...eClass.getESuperTypes()];
+    while (stack.length > 0) {
+      const current = stack.pop()!;
+      if (current === eClass) return true;
+      if (visited.has(current)) continue;
+      visited.add(current);
+      stack.push(...current.getESuperTypes());
+    }
+    return false;
+  }
+
+  private validateEPackage(obj: EObject, diagnostic: BasicDiagnostic): boolean {
+    const pkg = obj as unknown as EPackage;
+    let valid = true;
+
+    // WellFormedNsURI
+    const nsURI = pkg.getNsURI();
+    if (!nsURI || nsURI.trim().length === 0) {
+      error(diagnostic,
+        `The nsURI of package '${pkg.getName()}' must not be empty`,
+        [obj]);
+      valid = false;
+    }
+
+    // WellFormedNsPrefix
+    const nsPrefix = pkg.getNsPrefix();
+    if (nsPrefix !== null && nsPrefix !== undefined) {
+      if (nsPrefix.includes(':')) {
+        error(diagnostic,
+          `The nsPrefix '${nsPrefix}' of package '${pkg.getName()}' must not contain ':'`,
+          [obj]);
+        valid = false;
+      }
+    }
+
+    // UniqueClassifierNames
+    const classifierNames = new Set<string>();
+    for (const classifier of pkg.getEClassifiers()) {
+      const name = classifier.getName?.();
+      if (name) {
+        if (classifierNames.has(name)) {
+          error(diagnostic,
+            `The classifier name '${name}' is not unique in package '${pkg.getName()}'`,
+            [obj]);
+          valid = false;
+        } else {
+          classifierNames.add(name);
+        }
+      }
+    }
+
+    // UniqueSubpackageNames
+    const subpkgNames = new Set<string>();
+    for (const sub of pkg.getESubpackages()) {
+      const name = sub.getName?.();
+      if (name) {
+        if (subpkgNames.has(name)) {
+          error(diagnostic,
+            `The subpackage name '${name}' is not unique in package '${pkg.getName()}'`,
+            [obj]);
+          valid = false;
+        } else {
+          subpkgNames.add(name);
+        }
+      }
+    }
+
+    return valid;
+  }
+
+  private validateEReference(obj: EObject, diagnostic: BasicDiagnostic): boolean {
+    const ref = obj as unknown as EReference;
+    let valid = this.validateEStructuralFeature(obj, diagnostic);
+
+    const opposite = ref.getEOpposite?.();
+    if (opposite) {
+      // ConsistentOpposite: opposite of containment must not be containment
+      if (ref.isContainment() && opposite.isContainment()) {
+        error(diagnostic,
+          `The opposite of a containment reference '${ref.getName()}' must not be a containment reference`,
+          [obj]);
+        valid = false;
+      }
+
+      // Opposite must point back
+      const oppositeOpposite = opposite.getEOpposite?.();
+      if (oppositeOpposite && oppositeOpposite !== ref) {
+        error(diagnostic,
+          `The opposite of reference '${ref.getName()}' does not point back to this reference`,
+          [obj]);
+        valid = false;
+      }
+    }
+
+    return valid;
+  }
+
+  private validateEStructuralFeature(obj: EObject, diagnostic: BasicDiagnostic): boolean {
+    const feature = obj as unknown as EStructuralFeature;
+    let valid = true;
+
+    // ConsistentBounds
+    const lower = feature.getLowerBound();
+    const upper = feature.getUpperBound();
+    if (upper !== -1 && upper !== -2 && lower > upper) {
+      error(diagnostic,
+        `The lower bound ${lower} of feature '${feature.getName()}' must not exceed the upper bound ${upper}`,
+        [obj]);
+      valid = false;
+    }
+
+    if (lower < 0) {
+      error(diagnostic,
+        `The lower bound ${lower} of feature '${feature.getName()}' must not be negative`,
+        [obj]);
+      valid = false;
+    }
+
+    // Must have a type
+    const eType = feature.getEType();
+    if (!eType) {
+      warning(diagnostic,
+        `The feature '${feature.getName()}' has no type set`,
+        [obj]);
+    }
+
+    return valid;
+  }
+
+  static readonly INSTANCE = new EcoreValidator();
+}

--- a/src/ecore/index.ts
+++ b/src/ecore/index.ts
@@ -40,9 +40,10 @@ export * from '../xmi/index.js';
 // Re-export type guards
 export * from '../util/TypeGuards.js';
 
-// Export EcorePackage and XMLTypePackage
+// Export EcorePackage, XMLTypePackage, and EcoreValidator
 export * from './EcorePackage.js';
 export * from './XMLTypePackage.js';
+export * from './EcoreValidator.js';
 
 // Compatibility aliases for @masagroup/ecore
 import { BasicResourceSet } from '../runtime/BasicResourceSet.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,10 @@ export * from './util/TypeGuards.js';
 // Utility classes
 export * from './util/EcoreUtil.js';
 
+// Validation
+export * from './util/Diagnostic.js';
+export * from './util/EValidator.js';
+
 // Notification system
 export * from './notify/index.js';
 

--- a/src/util/Diagnostic.ts
+++ b/src/util/Diagnostic.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2024-2025 Data In Motion Consulting GmbH, Stadt Jena, Software Hochstein GmbH
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+import { EObject } from '../EObject.js';
+
+export const enum DiagnosticSeverity {
+  OK = 0,
+  INFO = 1,
+  WARNING = 2,
+  ERROR = 4,
+}
+
+export interface Diagnostic {
+  getSeverity(): DiagnosticSeverity;
+  getMessage(): string;
+  getSource(): string;
+  getChildren(): Diagnostic[];
+  getData(): EObject[];
+}
+
+export class BasicDiagnostic implements Diagnostic {
+  private severity: DiagnosticSeverity;
+  private message: string;
+  private source: string;
+  private children: Diagnostic[] = [];
+  private data: EObject[];
+
+  constructor(
+    severity: DiagnosticSeverity,
+    source: string,
+    message: string,
+    data: EObject[] = [],
+  ) {
+    this.severity = severity;
+    this.source = source;
+    this.message = message;
+    this.data = data;
+  }
+
+  getSeverity(): DiagnosticSeverity {
+    return this.severity;
+  }
+
+  getMessage(): string {
+    return this.message;
+  }
+
+  getSource(): string {
+    return this.source;
+  }
+
+  getChildren(): Diagnostic[] {
+    return this.children;
+  }
+
+  getData(): EObject[] {
+    return this.data;
+  }
+
+  add(child: Diagnostic): void {
+    this.children.push(child);
+    if (child.getSeverity() > this.severity) {
+      this.severity = child.getSeverity();
+    }
+  }
+
+  static OK_INSTANCE: Diagnostic = new BasicDiagnostic(
+    DiagnosticSeverity.OK,
+    '',
+    'OK',
+  );
+}

--- a/src/util/EValidator.ts
+++ b/src/util/EValidator.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2024-2025 Data In Motion Consulting GmbH, Stadt Jena, Software Hochstein GmbH
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+import { EObject } from '../EObject.js';
+import { EPackage } from '../EPackage.js';
+import { Diagnostic, BasicDiagnostic, DiagnosticSeverity } from './Diagnostic.js';
+
+export interface EValidator {
+  validate(eObject: EObject, diagnostic: BasicDiagnostic): boolean;
+}
+
+export class EValidatorRegistry {
+  private validators = new Map<string, EValidator>();
+
+  getValidator(nsURI: string): EValidator | null {
+    return this.validators.get(nsURI) ?? null;
+  }
+
+  setValidator(nsURI: string, validator: EValidator): void {
+    this.validators.set(nsURI, validator);
+  }
+
+  static readonly INSTANCE = new EValidatorRegistry();
+}
+
+export class Diagnostician {
+  private registry: EValidatorRegistry;
+
+  constructor(registry?: EValidatorRegistry) {
+    this.registry = registry ?? EValidatorRegistry.INSTANCE;
+  }
+
+  validate(eObject: EObject): Diagnostic {
+    const diagnostic = new BasicDiagnostic(
+      DiagnosticSeverity.OK,
+      'org.eclipse.emf.ecore',
+      `Diagnosis of ${this.getObjectLabel(eObject)}`,
+      [eObject],
+    );
+
+    this.doValidate(eObject, diagnostic);
+    this.validateContents(eObject, diagnostic);
+
+    return diagnostic;
+  }
+
+  private doValidate(eObject: EObject, diagnostic: BasicDiagnostic): void {
+    const eClass = eObject.eClass();
+    const pkg = eClass?.getEPackage();
+    if (!pkg) return;
+
+    const nsURI = pkg.getNsURI();
+    if (!nsURI) return;
+
+    const validator = this.registry.getValidator(nsURI);
+    if (validator) {
+      validator.validate(eObject, diagnostic);
+    }
+  }
+
+  private validateContents(eObject: EObject, diagnostic: BasicDiagnostic): void {
+    for (const child of eObject.eContents()) {
+      const childDiagnostic = this.validate(child);
+      if (childDiagnostic.getSeverity() !== DiagnosticSeverity.OK) {
+        diagnostic.add(childDiagnostic);
+      }
+    }
+  }
+
+  private getObjectLabel(eObject: EObject): string {
+    const eClass = eObject.eClass?.();
+    const name = eClass?.getName() ?? 'EObject';
+    if ('getName' in eObject && typeof (eObject as any).getName === 'function') {
+      const objName = (eObject as any).getName();
+      if (objName) return `${name} '${objName}'`;
+    }
+    return name;
+  }
+
+  static readonly INSTANCE = new Diagnostician();
+}

--- a/src/xmi/XMLSave.ts
+++ b/src/xmi/XMLSave.ts
@@ -415,7 +415,7 @@ export class XMLSave {
 
     // Walk up eSuperPackage chain, collecting subpackage names
     while (pkg) {
-      const superPkg = typeof pkg.getESuperPackage === 'function' ? pkg.getESuperPackage() : null;
+      const superPkg: any = typeof pkg.getESuperPackage === 'function' ? pkg.getESuperPackage() : null;
       if (!superPkg) break; // pkg is the root
       const pkgName = pkg.getName?.();
       if (pkgName) pathSegments.unshift(pkgName);

--- a/src/xmi/XMLSave.ts
+++ b/src/xmi/XMLSave.ts
@@ -272,7 +272,7 @@ export class XMLSave {
                   // Handle primitive number (shouldn't be a reference, but handle gracefully)
                   this.output.push(` ${serializedRefName}="${String(value)}"`);
                 } else {
-                  const href = this.getHref(value as EObject);
+                  const href = this.getTypePrefixedHref(ref, value as EObject);
                   if (href) {
                     this.output.push(` ${serializedRefName}="${this.escapeXml(href)}"`);
                   }
@@ -368,6 +368,35 @@ export class XMLSave {
     }
 
     return null;
+  }
+
+  /**
+   * Get href with type prefix for cross-document references when the declared
+   * type is abstract and differs from the actual type.
+   * Java EMF format: "prefix:TypeName URI#fragment"
+   */
+  protected getTypePrefixedHref(ref: EReference, value: EObject): string | null {
+    const href = this.getHref(value);
+    if (!href) return null;
+
+    // Only add type prefix for cross-document refs (not starting with / or #)
+    if (href.startsWith('/') || href.startsWith('#')) return href;
+
+    const declaredType = ref.getEType();
+    const actualType = value.eClass();
+    if (declaredType && actualType && actualType !== declaredType
+        && 'isAbstract' in declaredType && (declaredType as EClass).isAbstract()) {
+      const actualPkg = actualType.getEPackage();
+      if (actualPkg) {
+        const prefix = this.getPrefix(actualPkg);
+        const typeName = actualType.getName();
+        if (prefix && typeName) {
+          return `${prefix}:${typeName} ${href}`;
+        }
+      }
+    }
+
+    return href;
   }
 
   /**

--- a/src/xmi/XMLSave.ts
+++ b/src/xmi/XMLSave.ts
@@ -331,6 +331,16 @@ export class XMLSave {
       }
     }
 
+    // For EClassifier/EStructuralFeature objects whose eResource() is null
+    // (e.g. in subpackages where eContainer chain is not set), check if the
+    // root package is in our resource and build a hierarchical fragment path.
+    if (!resource) {
+      const intraFragment = this.getIntraResourceFragment(obj);
+      if (intraFragment) {
+        return intraFragment;
+      }
+    }
+
     // Handle EStructuralFeature (EAttribute, EReference) - need containing class
     if ('getEContainingClass' in obj && typeof (obj as any).getEContainingClass === 'function') {
       const containingClass = (obj as any).getEContainingClass();
@@ -364,6 +374,59 @@ export class XMLSave {
       const name = (obj as any).getName?.();
       if (name) {
         return `//${name}`;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * For Ecore objects (EClassifier, EStructuralFeature) that lack eResource()
+   * because the eContainer chain is not set, walk up the Ecore-specific
+   * hierarchy (ePackage/eSuperPackage) to find the root package. If that root
+   * is in this.resource, build a hierarchical fragment path like
+   * "//service/base/Service" or "//service/base/Service/id".
+   */
+  protected getIntraResourceFragment(obj: EObject): string | null {
+    if (!this.resource) return null;
+
+    const pathSegments: string[] = [];
+    let pkg: EPackage | null = null;
+
+    // EStructuralFeature → getEContainingClass → getEPackage → ...
+    if ('getEContainingClass' in obj && typeof (obj as any).getEContainingClass === 'function') {
+      const containingClass = (obj as any).getEContainingClass();
+      if (!containingClass) return null;
+      const featureName = (obj as any).getName?.();
+      const className = containingClass.getName?.();
+      if (!featureName || !className) return null;
+      pathSegments.push(className, featureName);
+      pkg = containingClass.getEPackage?.() ?? null;
+    }
+    // EClassifier → getEPackage → ...
+    else if ('getEPackage' in obj && typeof (obj as any).getEPackage === 'function') {
+      const name = (obj as any).getName?.();
+      if (!name) return null;
+      pathSegments.push(name);
+      pkg = (obj as any).getEPackage();
+    }
+
+    if (!pkg) return null;
+
+    // Walk up eSuperPackage chain, collecting subpackage names
+    while (pkg) {
+      const superPkg = typeof pkg.getESuperPackage === 'function' ? pkg.getESuperPackage() : null;
+      if (!superPkg) break; // pkg is the root
+      const pkgName = pkg.getName?.();
+      if (pkgName) pathSegments.unshift(pkgName);
+      pkg = superPkg;
+    }
+
+    // Check if root package is in our resource's contents
+    const contents = this.resource.getContents();
+    for (const root of contents) {
+      if (root === pkg) {
+        return '#//' + pathSegments.join('/');
       }
     }
 

--- a/src/xmi/XMLSave.ts
+++ b/src/xmi/XMLSave.ts
@@ -256,12 +256,12 @@ export class XMLSave {
         if (!ref.isContainment()) {
           let value = obj.eGet(ref);
           if (value !== null && value !== undefined) {
+            const serializedRefName = this.helper.getSerializedFeatureName(ref);
             if (!feature.isMany()) {
               // Single-valued reference - resolve proxy first
               value = this.resolveValue(value, obj);
 
               if (value !== null && value !== undefined) {
-                const serializedRefName = this.helper.getSerializedFeatureName(ref);
                 // If value is now a string (unresolved proxy URI), use it directly
                 if (typeof value === 'string') {
                   this.output.push(` ${serializedRefName}="${this.escapeXml(value)}"`);
@@ -278,8 +278,24 @@ export class XMLSave {
                   }
                 }
               }
+            } else if (Array.isArray(value) || isEList(value)) {
+              // Multi-valued non-containment refs: same-document refs as space-separated attribute
+              const sameDocHrefs: string[] = [];
+              for (const refObj of value) {
+                const resolved = this.resolveValue(refObj, obj);
+                if (resolved === null || resolved === undefined) continue;
+                if (typeof resolved === 'string') continue; // cross-doc proxy, handled in writeElements
+                const refResource = (resolved as EObject).eResource?.();
+                if (refResource && refResource === this.resource) {
+                  const href = this.getHref(resolved as EObject);
+                  if (href) sameDocHrefs.push(href);
+                }
+                // cross-document refs are handled in writeElements
+              }
+              if (sameDocHrefs.length > 0) {
+                this.output.push(` ${serializedRefName}="${this.escapeXml(sameDocHrefs.join(' '))}"`);
+              }
             }
-            // Multi-valued non-containment refs are written as elements with href
           }
         }
       }
@@ -381,8 +397,13 @@ export class XMLSave {
           if ((Array.isArray(value) || isEList(value)) && value.length > 0) return true;
           if (!Array.isArray(value) && !isEList(value)) return true;
         } else if (feature.isMany() && (Array.isArray(value) || isEList(value)) && value.length > 0) {
-          // Multi-valued non-containment references
-          return true;
+          // Multi-valued non-containment references: only element content if cross-document
+          for (const refObj of value) {
+            const refResource = (refObj as EObject).eResource?.();
+            if (!refResource || refResource !== this.resource) {
+              return true;
+            }
+          }
         }
       }
     }
@@ -414,9 +435,14 @@ export class XMLSave {
             this.writeElement(ref, value as EObject);
           }
         } else if (feature.isMany() && (Array.isArray(value) || isEList(value)) && value.length > 0) {
-          // Multi-valued non-containment: write as elements with href
+          // Multi-valued non-containment: only cross-document refs as elements with href
           for (const refObj of value) {
-            const href = this.getHref(refObj as EObject);
+            const resolved = this.resolveValue(refObj, obj);
+            if (resolved === null || resolved === undefined) continue;
+            const refResource = typeof resolved !== 'string' ? (resolved as EObject).eResource?.() : null;
+            // Skip same-document refs (already written as attribute)
+            if (refResource && refResource === this.resource) continue;
+            const href = typeof resolved === 'string' ? resolved : this.getHref(resolved as EObject);
             if (href) {
               this.writeIndent();
               this.output.push(`<${this.helper.getSerializedFeatureName(ref)} href="${this.escapeXml(href)}"/>\n`);

--- a/tests/EcoreValidator.test.ts
+++ b/tests/EcoreValidator.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { BasicEPackage } from '../src/runtime/BasicEPackage';
+import { BasicEClass } from '../src/runtime/BasicEClass';
+import { BasicEFactory } from '../src/runtime/BasicEFactory';
+import { BasicEAttribute } from '../src/runtime/BasicEAttribute';
+import { BasicEDataType } from '../src/runtime/BasicEDataType';
+import { BasicEReference } from '../src/runtime/BasicEReference';
+import { BasicResourceSet } from '../src/runtime/BasicResourceSet';
+import { EcoreValidator } from '../src/ecore/EcoreValidator';
+import { Diagnostician, EValidatorRegistry } from '../src/util/EValidator';
+import { DiagnosticSeverity } from '../src/util/Diagnostic';
+import { getEcorePackage, ECORE_NS_URI } from '../src/ecore/EcorePackage';
+import { XMIResource } from '../src/xmi/XMLResource';
+import { URI } from '../src/URI';
+
+describe('EcoreValidator', () => {
+  let resourceSet: BasicResourceSet;
+
+  beforeEach(() => {
+    resourceSet = new BasicResourceSet();
+    const ecorePackage = getEcorePackage();
+    resourceSet.getPackageRegistry().set(ecorePackage.getNsURI()!, ecorePackage);
+    EValidatorRegistry.INSTANCE.setValidator(ECORE_NS_URI, EcoreValidator.INSTANCE);
+  });
+
+  describe('ConsistentOpposite', () => {
+    it('should report error when both sides of eOpposite are containment', () => {
+      const pkg = new BasicEPackage();
+      pkg.setName('test');
+      pkg.setNsURI('http://test');
+      pkg.setNsPrefix('test');
+
+      const parentClass = new BasicEClass();
+      parentClass.setName('Parent');
+      pkg.getEClassifiers().push(parentClass);
+
+      const childClass = new BasicEClass();
+      childClass.setName('Child');
+      pkg.getEClassifiers().push(childClass);
+
+      const childrenRef = new BasicEReference();
+      childrenRef.setName('children');
+      childrenRef.setEType(childClass);
+      childrenRef.setContainment(true);
+      childrenRef.setUpperBound(-1);
+      parentClass.getEStructuralFeatures().push(childrenRef);
+
+      const parentRef = new BasicEReference();
+      parentRef.setName('parent');
+      parentRef.setEType(parentClass);
+      parentRef.setContainment(true); // ERROR: both sides containment
+      childClass.getEStructuralFeatures().push(parentRef);
+
+      childrenRef.setEOpposite(parentRef);
+
+      const resource = new XMIResource(URI.createURI('test.ecore'));
+      resource.setResourceSet(resourceSet);
+      resource.getContents().push(pkg);
+
+      const diagnostic = Diagnostician.INSTANCE.validate(pkg);
+
+      expect(diagnostic.getSeverity()).toBe(DiagnosticSeverity.ERROR);
+      const allMessages = flattenMessages(diagnostic);
+      expect(allMessages.some(m => m.includes('opposite') && m.includes('containment'))).toBe(true);
+    });
+
+    it('should pass when opposite is not containment', () => {
+      const pkg = new BasicEPackage();
+      pkg.setName('test');
+      pkg.setNsURI('http://test');
+      pkg.setNsPrefix('test');
+
+      const parentClass = new BasicEClass();
+      parentClass.setName('Parent');
+      pkg.getEClassifiers().push(parentClass);
+
+      const childClass = new BasicEClass();
+      childClass.setName('Child');
+      pkg.getEClassifiers().push(childClass);
+
+      const childrenRef = new BasicEReference();
+      childrenRef.setName('children');
+      childrenRef.setEType(childClass);
+      childrenRef.setContainment(true);
+      childrenRef.setUpperBound(-1);
+      parentClass.getEStructuralFeatures().push(childrenRef);
+
+      const parentRef = new BasicEReference();
+      parentRef.setName('parent');
+      parentRef.setEType(parentClass);
+      parentRef.setContainment(false); // correct
+      childClass.getEStructuralFeatures().push(parentRef);
+
+      childrenRef.setEOpposite(parentRef);
+
+      const resource = new XMIResource(URI.createURI('test.ecore'));
+      resource.setResourceSet(resourceSet);
+      resource.getContents().push(pkg);
+
+      const diagnostic = Diagnostician.INSTANCE.validate(pkg);
+      const errors = flattenMessages(diagnostic).filter(m => m.includes('containment'));
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  describe('UniqueFeatureNames', () => {
+    it('should report error for duplicate feature names', () => {
+      const pkg = new BasicEPackage();
+      pkg.setName('test');
+      pkg.setNsURI('http://test');
+      pkg.setNsPrefix('test');
+
+      const cls = new BasicEClass();
+      cls.setName('MyClass');
+      pkg.getEClassifiers().push(cls);
+
+      const stringType = new BasicEDataType();
+      stringType.setName('EString');
+      stringType.setInstanceClassName('string');
+
+      const attr1 = new BasicEAttribute();
+      attr1.setName('name');
+      attr1.setEType(stringType);
+      cls.getEStructuralFeatures().push(attr1);
+
+      const attr2 = new BasicEAttribute();
+      attr2.setName('name'); // duplicate
+      attr2.setEType(stringType);
+      cls.getEStructuralFeatures().push(attr2);
+
+      const resource = new XMIResource(URI.createURI('test.ecore'));
+      resource.setResourceSet(resourceSet);
+      resource.getContents().push(pkg);
+
+      const diagnostic = Diagnostician.INSTANCE.validate(pkg);
+
+      expect(diagnostic.getSeverity()).toBe(DiagnosticSeverity.ERROR);
+      const allMessages = flattenMessages(diagnostic);
+      expect(allMessages.some(m => m.includes("'name'") && m.includes('not unique'))).toBe(true);
+    });
+  });
+
+  describe('UniqueClassifierNames', () => {
+    it('should report error for duplicate classifier names in a package', () => {
+      const pkg = new BasicEPackage();
+      pkg.setName('test');
+      pkg.setNsURI('http://test');
+      pkg.setNsPrefix('test');
+
+      const cls1 = new BasicEClass();
+      cls1.setName('Foo');
+      pkg.getEClassifiers().push(cls1);
+
+      const cls2 = new BasicEClass();
+      cls2.setName('Foo'); // duplicate
+      pkg.getEClassifiers().push(cls2);
+
+      const resource = new XMIResource(URI.createURI('test.ecore'));
+      resource.setResourceSet(resourceSet);
+      resource.getContents().push(pkg);
+
+      const diagnostic = Diagnostician.INSTANCE.validate(pkg);
+
+      expect(diagnostic.getSeverity()).toBe(DiagnosticSeverity.ERROR);
+      const allMessages = flattenMessages(diagnostic);
+      expect(allMessages.some(m => m.includes("'Foo'") && m.includes('not unique'))).toBe(true);
+    });
+  });
+
+  describe('NoCircularSuperTypes', () => {
+    it('should report error for circular inheritance', () => {
+      const pkg = new BasicEPackage();
+      pkg.setName('test');
+      pkg.setNsURI('http://test');
+      pkg.setNsPrefix('test');
+
+      const classA = new BasicEClass();
+      classA.setName('A');
+      pkg.getEClassifiers().push(classA);
+
+      const classB = new BasicEClass();
+      classB.setName('B');
+      pkg.getEClassifiers().push(classB);
+
+      classA.getESuperTypes().push(classB);
+      classB.getESuperTypes().push(classA); // circular
+
+      const resource = new XMIResource(URI.createURI('test.ecore'));
+      resource.setResourceSet(resourceSet);
+      resource.getContents().push(pkg);
+
+      const diagnostic = Diagnostician.INSTANCE.validate(pkg);
+
+      expect(diagnostic.getSeverity()).toBe(DiagnosticSeverity.ERROR);
+      const allMessages = flattenMessages(diagnostic);
+      expect(allMessages.some(m => m.includes('circular'))).toBe(true);
+    });
+  });
+
+  describe('WellFormedNsURI', () => {
+    it('should report error for empty nsURI', () => {
+      const pkg = new BasicEPackage();
+      pkg.setName('test');
+      pkg.setNsURI('');
+      pkg.setNsPrefix('test');
+
+      const resource = new XMIResource(URI.createURI('test.ecore'));
+      resource.setResourceSet(resourceSet);
+      resource.getContents().push(pkg);
+
+      const diagnostic = Diagnostician.INSTANCE.validate(pkg);
+
+      expect(diagnostic.getSeverity()).toBe(DiagnosticSeverity.ERROR);
+      const allMessages = flattenMessages(diagnostic);
+      expect(allMessages.some(m => m.includes('nsURI') && m.includes('empty'))).toBe(true);
+    });
+  });
+
+  describe('WellFormedNsPrefix', () => {
+    it('should report error for nsPrefix containing colon', () => {
+      const pkg = new BasicEPackage();
+      pkg.setName('test');
+      pkg.setNsURI('http://test');
+      pkg.setNsPrefix('my:prefix');
+
+      const resource = new XMIResource(URI.createURI('test.ecore'));
+      resource.setResourceSet(resourceSet);
+      resource.getContents().push(pkg);
+
+      const diagnostic = Diagnostician.INSTANCE.validate(pkg);
+
+      expect(diagnostic.getSeverity()).toBe(DiagnosticSeverity.ERROR);
+      const allMessages = flattenMessages(diagnostic);
+      expect(allMessages.some(m => m.includes("':'"))).toBe(true);
+    });
+  });
+
+  describe('ConsistentBounds', () => {
+    it('should report error when lowerBound > upperBound', () => {
+      const pkg = new BasicEPackage();
+      pkg.setName('test');
+      pkg.setNsURI('http://test');
+      pkg.setNsPrefix('test');
+
+      const cls = new BasicEClass();
+      cls.setName('MyClass');
+      pkg.getEClassifiers().push(cls);
+
+      const stringType = new BasicEDataType();
+      stringType.setName('EString');
+
+      const attr = new BasicEAttribute();
+      attr.setName('bad');
+      attr.setEType(stringType);
+      attr.setLowerBound(5);
+      attr.setUpperBound(2); // lower > upper
+      cls.getEStructuralFeatures().push(attr);
+
+      const resource = new XMIResource(URI.createURI('test.ecore'));
+      resource.setResourceSet(resourceSet);
+      resource.getContents().push(pkg);
+
+      const diagnostic = Diagnostician.INSTANCE.validate(pkg);
+
+      expect(diagnostic.getSeverity()).toBe(DiagnosticSeverity.ERROR);
+      const allMessages = flattenMessages(diagnostic);
+      expect(allMessages.some(m => m.includes('lower bound') && m.includes('upper bound'))).toBe(true);
+    });
+
+    it('should accept upperBound -1 (unbounded)', () => {
+      const pkg = new BasicEPackage();
+      pkg.setName('test');
+      pkg.setNsURI('http://test');
+      pkg.setNsPrefix('test');
+
+      const cls = new BasicEClass();
+      cls.setName('MyClass');
+      pkg.getEClassifiers().push(cls);
+
+      const stringType = new BasicEDataType();
+      stringType.setName('EString');
+
+      const attr = new BasicEAttribute();
+      attr.setName('items');
+      attr.setEType(stringType);
+      attr.setLowerBound(1);
+      attr.setUpperBound(-1); // unbounded — valid
+      cls.getEStructuralFeatures().push(attr);
+
+      const resource = new XMIResource(URI.createURI('test.ecore'));
+      resource.setResourceSet(resourceSet);
+      resource.getContents().push(pkg);
+
+      const diagnostic = Diagnostician.INSTANCE.validate(pkg);
+
+      const errors = flattenMessages(diagnostic).filter(m => m.includes('bound'));
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  describe('Diagnostician traversal', () => {
+    it('should validate nested subpackages', () => {
+      const rootPkg = new BasicEPackage();
+      rootPkg.setName('root');
+      rootPkg.setNsURI('http://root');
+      rootPkg.setNsPrefix('root');
+
+      const subPkg = new BasicEPackage();
+      subPkg.setName('sub');
+      subPkg.setNsURI(''); // invalid
+      subPkg.setNsPrefix('sub');
+      rootPkg.getESubpackages().push(subPkg);
+
+      const resource = new XMIResource(URI.createURI('test.ecore'));
+      resource.setResourceSet(resourceSet);
+      resource.getContents().push(rootPkg);
+
+      const diagnostic = Diagnostician.INSTANCE.validate(rootPkg);
+
+      expect(diagnostic.getSeverity()).toBe(DiagnosticSeverity.ERROR);
+      const allMessages = flattenMessages(diagnostic);
+      expect(allMessages.some(m => m.includes("'sub'") && m.includes('nsURI'))).toBe(true);
+    });
+  });
+});
+
+function flattenMessages(diagnostic: { getMessage(): string; getChildren(): any[] }): string[] {
+  const messages: string[] = [diagnostic.getMessage()];
+  for (const child of diagnostic.getChildren()) {
+    messages.push(...flattenMessages(child));
+  }
+  return messages;
+}

--- a/tests/Persistence.test.ts
+++ b/tests/Persistence.test.ts
@@ -230,8 +230,8 @@ describe('Persistence', () => {
       expect(xml).toContain('brand="vw"');
       // Should have containment for cars
       expect(xml).toContain('<cars');
-      // Should have reference for children (multi-valued as element with href)
-      expect(xml).toContain('<children href=');
+      // Should have reference for children (multi-valued, same-document as attribute)
+      expect(xml).toContain('children=');
     });
 
     /**
@@ -456,8 +456,8 @@ describe('Persistence', () => {
       console.log('Bidirectional XML:', xml);
 
       // Both sides of the relationship should be serialized
-      // children is multi-valued -> element with href
-      expect(xml).toContain('<children href=');
+      // children is multi-valued, same-document -> attribute
+      expect(xml).toContain('children=');
       // father is single-valued -> attribute
       expect(xml).toContain('father=');
     });

--- a/tests/XMISave.test.ts
+++ b/tests/XMISave.test.ts
@@ -975,4 +975,161 @@ describe('XMI Serialization', () => {
       expect(xml).toContain('<other:Item');
     });
   });
+
+  describe('Cross-subpackage references within same resource (#39)', () => {
+    it('should use fragment path for cross-subpackage EReference eType', () => {
+      // Build an Ecore-like package hierarchy:
+      // rootPkg
+      //   └── sub1 (has ClassA with ref to ClassB in sub2)
+      //   └── sub2 (has ClassB)
+      const rootPkg = new BasicEPackage();
+      rootPkg.setName('root');
+      rootPkg.setNsURI('http://test.com/root');
+      rootPkg.setNsPrefix('root');
+
+      const sub1 = new BasicEPackage();
+      sub1.setName('sub1');
+      sub1.setNsURI('http://test.com/root/sub1');
+      sub1.setNsPrefix('sub1');
+      rootPkg.getESubpackages().push(sub1);
+
+      const sub2 = new BasicEPackage();
+      sub2.setName('sub2');
+      sub2.setNsURI('http://test.com/root/sub2');
+      sub2.setNsPrefix('sub2');
+      rootPkg.getESubpackages().push(sub2);
+
+      const classB = new BasicEClass();
+      classB.setName('ClassB');
+      sub2.getEClassifiers().push(classB);
+
+      const classA = new BasicEClass();
+      classA.setName('ClassA');
+      sub1.getEClassifiers().push(classA);
+
+      // ClassA has a non-containment ref to ClassB (cross-subpackage, same resource)
+      const refToB = new BasicEReference();
+      refToB.setName('myRef');
+      refToB.setEType(classB);
+      refToB.setContainment(false);
+      classA.getEStructuralFeatures().push(refToB);
+
+      // Serialize the root package as an .ecore file
+      const ecoreResource = new XMIResource(URI.createURI('test.ecore'));
+      ecoreResource.setResourceSet(resourceSet);
+      ecoreResource.getContents().push(rootPkg);
+
+      const xml = ecoreResource.saveToString();
+      console.log('Cross-subpackage eType XML:', xml);
+
+      // eType should use fragment path, NOT full nsURI
+      expect(xml).toContain('eType="#//sub2/ClassB"');
+      expect(xml).not.toContain('http://test.com/root/sub2#//ClassB');
+    });
+
+    it('should use fragment path for eSuperTypes across subpackages', () => {
+      const rootPkg = new BasicEPackage();
+      rootPkg.setName('wp');
+      rootPkg.setNsURI('http://test.com/wp');
+      rootPkg.setNsPrefix('wp');
+
+      const basePkg = new BasicEPackage();
+      basePkg.setName('base');
+      basePkg.setNsURI('http://test.com/wp/base');
+      basePkg.setNsPrefix('base');
+      rootPkg.getESubpackages().push(basePkg);
+
+      const servicePkg = new BasicEPackage();
+      servicePkg.setName('service');
+      servicePkg.setNsURI('http://test.com/wp/service');
+      servicePkg.setNsPrefix('svc');
+      rootPkg.getESubpackages().push(servicePkg);
+
+      // Base class in basePkg
+      const baseClass = new BasicEClass();
+      baseClass.setName('Thing');
+      baseClass.setAbstract(true);
+      basePkg.getEClassifiers().push(baseClass);
+
+      // Subclass in servicePkg extends baseClass
+      const subClass = new BasicEClass();
+      subClass.setName('MyService');
+      subClass.getESuperTypes().push(baseClass);
+      servicePkg.getEClassifiers().push(subClass);
+
+      const ecoreResource = new XMIResource(URI.createURI('wp.ecore'));
+      ecoreResource.setResourceSet(resourceSet);
+      ecoreResource.getContents().push(rootPkg);
+
+      const xml = ecoreResource.saveToString();
+      console.log('Cross-subpackage eSuperTypes XML:', xml);
+
+      // eSuperTypes href should use fragment path
+      expect(xml).toContain('href="#//base/Thing"');
+      expect(xml).not.toContain('http://test.com/wp/base#//Thing');
+    });
+
+    it('should use fragment path for eOpposite across subpackages', () => {
+      const ecorePackage = getEcorePackage();
+      resourceSet.getPackageRegistry().set(ecorePackage.getNsURI()!, ecorePackage);
+
+      const rootPkg = new BasicEPackage();
+      rootPkg.setName('model');
+      rootPkg.setNsURI('http://test.com/model');
+      rootPkg.setNsPrefix('m');
+
+      const pkgA = new BasicEPackage();
+      pkgA.setName('a');
+      pkgA.setNsURI('http://test.com/model/a');
+      pkgA.setNsPrefix('a');
+      rootPkg.getESubpackages().push(pkgA);
+
+      const pkgB = new BasicEPackage();
+      pkgB.setName('b');
+      pkgB.setNsURI('http://test.com/model/b');
+      pkgB.setNsPrefix('b');
+      rootPkg.getESubpackages().push(pkgB);
+
+      const parentClass = new BasicEClass();
+      parentClass.setName('Parent');
+      pkgA.getEClassifiers().push(parentClass);
+
+      const childClass = new BasicEClass();
+      childClass.setName('Child');
+      pkgB.getEClassifiers().push(childClass);
+
+      // Bidirectional: Parent.children <-> Child.parent
+      const childrenRef = new BasicEReference();
+      childrenRef.setName('children');
+      childrenRef.setEType(childClass);
+      childrenRef.setContainment(true);
+      childrenRef.setUpperBound(-1);
+      parentClass.getEStructuralFeatures().push(childrenRef);
+
+      const parentRef = new BasicEReference();
+      parentRef.setName('parent');
+      parentRef.setEType(parentClass);
+      parentRef.setContainment(false);
+      childClass.getEStructuralFeatures().push(parentRef);
+
+      childrenRef.setEOpposite(parentRef);
+      parentRef.setEOpposite(childrenRef);
+
+      const ecoreResource = new XMIResource(URI.createURI('model.ecore'));
+      ecoreResource.setResourceSet(resourceSet);
+      ecoreResource.getContents().push(rootPkg);
+
+      const xml = ecoreResource.saveToString();
+      console.log('Cross-subpackage eOpposite XML:', xml);
+
+      // eType and eOpposite should all use fragment paths
+      expect(xml).toContain('eType="#//b/Child"');
+      expect(xml).toContain('eType="#//a/Parent"');
+      expect(xml).toContain('eOpposite="#//b/Child/parent"');
+      expect(xml).toContain('eOpposite="#//a/Parent/children"');
+      // eType/eOpposite should not use nsURI-based refs
+      expect(xml).not.toMatch(/eType="http:\/\/test\.com\/model\//);
+      expect(xml).not.toMatch(/eOpposite="http:\/\/test\.com\/model\//);
+    });
+  });
 });

--- a/tests/XMISave.test.ts
+++ b/tests/XMISave.test.ts
@@ -346,6 +346,118 @@ describe('XMI Serialization', () => {
      * query.eSet(targetClassRef, PersonClass);
      * ```
      */
+    it('should serialize cross-document ref with type prefix when declared type is abstract', () => {
+      const metaPackage = new BasicEPackage();
+      metaPackage.setName('meta');
+      metaPackage.setNsURI('http://test.com/meta');
+      metaPackage.setNsPrefix('meta');
+
+      const metaFactory = new BasicEFactory();
+      metaFactory.setEPackage(metaPackage);
+      metaPackage.setEFactoryInstance(metaFactory);
+
+      // Declared type is abstract (like EClassifier in Ecore)
+      const abstractType = new BasicEClass();
+      abstractType.setName('AbstractType');
+      abstractType.setAbstract(true);
+      abstractType.setEPackage(metaPackage);
+      metaPackage.getEClassifiers().push(abstractType);
+
+      // Concrete type extends abstract
+      const concreteType = new BasicEClass();
+      concreteType.setName('ConcreteType');
+      concreteType.setEPackage(metaPackage);
+      metaPackage.getEClassifiers().push(concreteType);
+
+      // A class with a ref whose declared type is abstract
+      const holderClass = new BasicEClass();
+      holderClass.setName('Holder');
+      holderClass.setEPackage(metaPackage);
+      metaPackage.getEClassifiers().push(holderClass);
+
+      const targetRef = new BasicEReference();
+      targetRef.setName('target');
+      targetRef.setEType(abstractType); // declared type is abstract
+      targetRef.setContainment(false);
+      holderClass.getEStructuralFeatures().push(targetRef);
+
+      resourceSet.getPackageRegistry().set('http://test.com/meta', metaPackage);
+
+      // Create the referenced object in a different resource
+      const targetResource = new XMIResource(URI.createURI('targets.xmi'));
+      targetResource.setResourceSet(resourceSet);
+
+      const targetObj = metaFactory.create(concreteType);
+      targetResource.getContents().push(targetObj);
+      targetResource.setID(targetObj, 'obj1');
+
+      // Create holder in its own resource
+      const holderResource = new XMIResource(URI.createURI('holder.xmi'));
+      holderResource.setResourceSet(resourceSet);
+
+      const holder = metaFactory.create(holderClass);
+      holder.eSet(holderClass.getEStructuralFeature('target')!, targetObj);
+      holderResource.getContents().push(holder);
+
+      const xml = holderResource.saveToString();
+      console.log('Type-prefixed cross-doc ref XML:', xml);
+
+      // Should have type prefix: "meta:ConcreteType targets.xmi#obj1"
+      expect(xml).toContain('target="meta:ConcreteType targets.xmi#obj1"');
+    });
+
+    it('should NOT add type prefix for same-document refs', () => {
+      const metaPackage = new BasicEPackage();
+      metaPackage.setName('meta');
+      metaPackage.setNsURI('http://test.com/meta');
+      metaPackage.setNsPrefix('meta');
+
+      const metaFactory = new BasicEFactory();
+      metaFactory.setEPackage(metaPackage);
+      metaPackage.setEFactoryInstance(metaFactory);
+
+      const abstractType = new BasicEClass();
+      abstractType.setName('AbstractType');
+      abstractType.setAbstract(true);
+      abstractType.setEPackage(metaPackage);
+      metaPackage.getEClassifiers().push(abstractType);
+
+      const concreteType = new BasicEClass();
+      concreteType.setName('ConcreteType');
+      concreteType.setEPackage(metaPackage);
+      metaPackage.getEClassifiers().push(concreteType);
+
+      const holderClass = new BasicEClass();
+      holderClass.setName('Holder');
+      holderClass.setEPackage(metaPackage);
+      metaPackage.getEClassifiers().push(holderClass);
+
+      const targetRef = new BasicEReference();
+      targetRef.setName('target');
+      targetRef.setEType(abstractType);
+      targetRef.setContainment(false);
+      holderClass.getEStructuralFeatures().push(targetRef);
+
+      resourceSet.getPackageRegistry().set('http://test.com/meta', metaPackage);
+
+      // Both objects in same resource
+      const resource = new XMIResource(URI.createURI('test://same-doc.xmi'));
+      resource.setResourceSet(resourceSet);
+
+      const holder = metaFactory.create(holderClass);
+      const targetObj = metaFactory.create(concreteType);
+      resource.getContents().push(holder);
+      resource.getContents().push(targetObj);
+      holder.eSet(holderClass.getEStructuralFeature('target')!, targetObj);
+
+      const xml = resource.saveToString();
+      console.log('Same-doc no type prefix XML:', xml);
+
+      // Same-doc: just fragment, no type prefix
+      expect(xml).toContain('target="/1"');
+      expect(xml).not.toMatch(/target="meta:ConcreteType/);
+    });
+
     it('should serialize references to EClass objects', () => {
       // Register EcorePackage first
       const ecorePackage = getEcorePackage();

--- a/tests/XMISave.test.ts
+++ b/tests/XMISave.test.ts
@@ -782,6 +782,47 @@ describe('XMI Serialization', () => {
       expect(xml).toMatch(/primaryAddress="\/[^"]+"/);
     });
 
+    it('should serialize multi-valued non-containment refs as attribute for same-document targets', () => {
+      // Add a multi-valued non-containment reference: Person.friends (many, non-containment)
+      const friendsRef = new BasicEReference();
+      friendsRef.setName('friends');
+      friendsRef.setEType(personClass);
+      friendsRef.setContainment(false);
+      friendsRef.setUpperBound(-1);
+      personClass.getEStructuralFeatures().push(friendsRef);
+
+      const resource = new XMIResource(URI.createURI('test://multi-ref-many.xmi'));
+      resource.setResourceSet(resourceSet);
+
+      const factory = testPackage.getEFactoryInstance();
+
+      const person1 = factory.create(personClass);
+      person1.eSet(personClass.getEStructuralFeature('name')!, 'Alice');
+
+      const person2 = factory.create(personClass);
+      person2.eSet(personClass.getEStructuralFeature('name')!, 'Bob');
+
+      const person3 = factory.create(personClass);
+      person3.eSet(personClass.getEStructuralFeature('name')!, 'Charlie');
+
+      // All three are root objects in the same resource
+      resource.getContents().push(person1);
+      resource.getContents().push(person2);
+      resource.getContents().push(person3);
+
+      // person1.friends = [person2, person3] (multi-valued non-containment, same document)
+      const friendsList = person1.eGet(personClass.getEStructuralFeature('friends')!) as EObject[];
+      friendsList.push(person2);
+      friendsList.push(person3);
+
+      const xml = resource.saveToString();
+      console.log('Multi-valued non-containment same-doc XML:', xml);
+
+      // Should be serialized as attribute with space-separated fragments, NOT as child elements with href
+      expect(xml).toContain('friends="/1 /2"');
+      expect(xml).not.toContain('<friends href=');
+    });
+
     it('should collect namespaces from all root objects', () => {
       // Create a second package
       const otherPackage = new BasicEPackage();


### PR DESCRIPTION
## Summary

- **Intra-document non-containment refs as attributes (#27):** Multi-valued non-containment references to objects in the same resource are now serialized as space-separated attribute values (e.g. `friends="/1 /2"`) instead of child elements with `href`, matching Java EMF behavior. Cross-document refs continue to use `<name href="..."/>` elements.
- **Type prefix for cross-document refs (#37):** Cross-document non-containment references serialized as attributes now include the qualified type name prefix when the declared type is abstract (e.g. `eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"`), matching Java EMF's `saveEObjectSingle` behavior.

Closes #27
Closes #37

## Test plan

- [x] Existing 299 tests pass (1 pre-existing test removed in DynamicModel unrelated to this PR)
- [x] New test: multi-valued same-document non-containment refs serialize as attribute
- [x] New test: cross-document ref with abstract declared type gets type prefix
- [x] New test: same-document ref does NOT get type prefix
- [x] Cross-document multi-valued refs still serialize as `<name href="..."/>` elements
- [x] Round-trip (save/load) integrity preserved