### PR TITLE
fix: always check intra-resource fragment before eResource fallback

### DIFF
--- a/src/xmi/XMLSave.ts
+++ b/src/xmi/XMLSave.ts
@@ -312,6 +312,14 @@ export class XMLSave {
       return proxyURI?.toString() || null;
     }
 
+    // For EClassifier/EStructuralFeature in subpackages, always check if the
+    // root package is in our resource — regardless of what eResource() returns,
+    // since the eContainer chain may point to a different resource instance.
+    const intraFragment = this.getIntraResourceFragment(obj);
+    if (intraFragment) {
+      return intraFragment;
+    }
+
     const resource = obj.eResource?.();
 
     // Try to get URI fragment from resource
@@ -328,16 +336,6 @@ export class XMLSave {
           return `${uri.toString()}#${fragment}`;
         }
         return `#${fragment}`;
-      }
-    }
-
-    // For EClassifier/EStructuralFeature objects whose eResource() is null
-    // (e.g. in subpackages where eContainer chain is not set), check if the
-    // root package is in our resource and build a hierarchical fragment path.
-    if (!resource) {
-      const intraFragment = this.getIntraResourceFragment(obj);
-      if (intraFragment) {
-        return intraFragment;
       }
     }
 

--- a/tests/XMISave.test.ts
+++ b/tests/XMISave.test.ts
@@ -1131,5 +1131,41 @@ describe('XMI Serialization', () => {
       expect(xml).not.toMatch(/eType="http:\/\/test\.com\/model\//);
       expect(xml).not.toMatch(/eOpposite="http:\/\/test\.com\/model\//);
     });
+
+    it('should use fragment paths on round-trip (load then re-serialize)', () => {
+      const ecorePackage = getEcorePackage();
+      resourceSet.getPackageRegistry().set(ecorePackage.getNsURI()!, ecorePackage);
+
+      // An ecore with cross-subpackage eType and eSuperTypes using correct fragment paths
+      const inputXml = `<?xml version="1.0" encoding="UTF-8"?>
+<ecore:EPackage xmlns:xmi="http://www.omg.org/XMI" xmi:version="2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="wp" nsURI="http://test.com/wp" nsPrefix="wp">
+  <eSubpackages name="base" nsURI="http://test.com/wp/base" nsPrefix="base">
+    <eClassifiers xsi:type="ecore:EClass" name="Thing" abstract="true">
+      <eStructuralFeatures xsi:type="ecore:EAttribute" name="id" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    </eClassifiers>
+  </eSubpackages>
+  <eSubpackages name="service" nsURI="http://test.com/wp/service" nsPrefix="svc">
+    <eClassifiers xsi:type="ecore:EClass" name="MyService">
+      <eSuperTypes href="#//base/Thing"/>
+      <eStructuralFeatures xsi:type="ecore:EReference" name="relatedThing" eType="#//base/Thing"/>
+    </eClassifiers>
+  </eSubpackages>
+</ecore:EPackage>`;
+
+      const loadResource = new XMIResource(URI.createURI('wp.ecore'));
+      loadResource.setResourceSet(resourceSet);
+      loadResource.loadFromString(inputXml);
+
+      // Re-serialize — objects now have eResource() set from load
+      const outputXml = loadResource.saveToString();
+
+      // eSuperTypes must still use fragment path, NOT nsURI-based href
+      expect(outputXml).toContain('href="#//base/Thing"');
+      expect(outputXml).not.toMatch(/href="http:\/\/test\.com\/wp\/base/);
+
+      // eType for cross-subpackage ref must use fragment path
+      expect(outputXml).toContain('eType="#//base/Thing"');
+      expect(outputXml).not.toMatch(/eType="http:\/\/test\.com\/wp\/base/);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- `getIntraResourceFragment()` was only called when `eResource()` returned null, but in round-trip scenarios (load → re-serialize) `eResource()` is set, causing cross-subpackage references to fall through to nsURI-based hrefs instead of fragment paths (`#//subpkg/Class`)
- Move the `getIntraResourceFragment` check before the `eResource()` check so it always takes priority for objects whose root package is in the serializing resource
- Fixes the remaining waterpark2.ecore serialization issues where eSuperTypes/eType/eOpposite still used nsURI-based cross-document hrefs after #39

## Test plan

- [x] New round-trip test: load ecore with cross-subpackage refs, re-serialize, verify fragment paths preserved
- [x] All 318 tests passing
- [x] Existing #39 tests still green