### PR TITLE
fix: guard isContainment calls in EcoreValidator for proxy opposites (#43)

### DIFF
--- a/src/ecore/EcoreValidator.ts
+++ b/src/ecore/EcoreValidator.ts
@@ -156,7 +156,7 @@ export class EcoreValidator implements EValidator {
     const opposite = ref.getEOpposite?.();
     if (opposite) {
       // ConsistentOpposite: opposite of containment must not be containment
-      if (ref.isContainment() && opposite.isContainment()) {
+      if (ref.isContainment?.() && opposite.isContainment?.()) {
         error(diagnostic,
           `The opposite of a containment reference '${ref.getName()}' must not be a containment reference`,
           [obj]);


### PR DESCRIPTION
## Summary

- `EcoreValidator.validateEReference` called `opposite.isContainment()` without guarding against proxies or lightweight EObjects that lack that method, causing `TypeError: opposite.isContainment is not a function`
- Changed to `opposite.isContainment?.()` so validation degrades gracefully instead of throwing

Closes #43

## Test plan

- [x] All 318 tests passing