### PR TITLE
fix: write xmi:id attributes during XMLSave serialization

### DIFF
--- a/src/xmi/XMLHelper.ts
+++ b/src/xmi/XMLHelper.ts
@@ -16,6 +16,7 @@ import { EStructuralFeature } from '../EStructuralFeature.js';
 import { EReference } from '../EReference.js';
 import { Resource } from '../Resource.js';
 import { URI } from '../URI.js';
+import type { XMLResource } from './XMLResource.js';
 /**
  * Option key for feature name mapping.
  * Value: Map<string, string> where key = feature name, value = XML name
@@ -86,6 +87,9 @@ export interface XMLHelper {
   deresolve(uri: URI): URI;
   resolve(relative: URI, base: URI): URI;
 
+  // ID handling
+  getID(obj: EObject): string | null;
+
   // Conversion
   convertToString(factory: EFactory, dataType: EDataType, data: any): string;
 }
@@ -142,6 +146,7 @@ class NamespaceSupport {
 export class XMLHelperImpl implements XMLHelper {
   protected noNamespacePackage: EPackage | null = null;
   protected resource: Resource | null = null;
+  protected xmlResource: XMLResource | null = null;
   protected resourceURI: URI | null = null;
   protected packageRegistry: EPackageRegistry = EPackageRegistry.INSTANCE;
 
@@ -165,6 +170,7 @@ export class XMLHelperImpl implements XMLHelper {
 
   setResource(resource: Resource): void {
     this.resource = resource;
+    this.xmlResource = (resource && 'getID' in resource) ? resource as XMLResource : null;
     if (resource) {
       this.resourceURI = resource.getURI();
       const resourceSet = resource.getResourceSet();
@@ -444,6 +450,10 @@ export class XMLHelperImpl implements XMLHelper {
 
   resolve(relative: URI, base: URI): URI {
     return relative.resolve(base);
+  }
+
+  getID(obj: EObject): string | null {
+    return this.xmlResource ? this.xmlResource.getID(obj) : null;
   }
 
   convertToString(factory: EFactory, dataType: EDataType, data: any): string {

--- a/src/xmi/XMLSave.ts
+++ b/src/xmi/XMLSave.ts
@@ -30,6 +30,7 @@ export class XMLSave {
   protected output: string[] = [];
   protected indent: number = 0;
   protected indentString: string = '  ';
+  protected idAttributeName: string = 'id';
 
   constructor(helper?: XMLHelper) {
     this.helper = helper || new XMLHelperImpl();
@@ -133,6 +134,9 @@ export class XMLSave {
       this.writeTypeAttribute(obj);
     }
 
+    // Write xmi:id if present
+    this.saveID(obj);
+
     // Write attributes
     this.writeAttributes(obj);
 
@@ -151,6 +155,16 @@ export class XMLSave {
       this.output.push(`</${qName}>\n`);
     } else {
       this.output.push('/>\n');
+    }
+  }
+
+  /**
+   * Write xmi:id attribute if the resource tracks an ID for this object
+   */
+  protected saveID(obj: EObject): void {
+    const id = this.helper.getID(obj);
+    if (id) {
+      this.output.push(` ${this.idAttributeName}="${this.escapeXml(id)}"`);
     }
   }
 
@@ -563,6 +577,9 @@ export class XMLSave {
       this.output.push(` xsi:type="${typeName}"`);
     }
 
+    // Write xmi:id if present
+    this.saveID(value);
+
     // Write attributes
     this.writeAttributes(value);
 
@@ -742,6 +759,11 @@ export class XMLSave {
  * XMI-specific save implementation
  */
 export class XMISave extends XMLSave {
+  constructor(helper?: XMLHelper) {
+    super(helper);
+    this.idAttributeName = 'xmi:id';
+  }
+
   protected override writeNamespaces(obj: EObject): void {
     super.writeNamespaces(obj);
   }

--- a/tests/XMI.test.ts
+++ b/tests/XMI.test.ts
@@ -131,6 +131,56 @@ describe('XMI Loading', () => {
       expect(resource.getID(obj)).toBe('obj1');
       expect(resource.getEObject('obj1')).toBe(obj);
     });
+
+    it('should write xmi:id attributes during save', () => {
+      const resource = new XMIResource(URI.createURI('test://model.xmi'));
+
+      const pkg = new BasicEPackage();
+      pkg.setName('test');
+      pkg.setNsURI('http://test.com/model');
+      pkg.setNsPrefix('test');
+
+      const factory = new BasicEFactory(pkg);
+      pkg.setEFactoryInstance(factory);
+
+      const eClass = new BasicEClass();
+      eClass.setName('Item');
+      pkg.getEClassifiers().push(eClass);
+
+      const obj = factory.create(eClass);
+      resource.getContents().push(obj);
+      resource.setID(obj, 'item_42');
+
+      const xml = resource.saveToString();
+      expect(xml).toContain('xmi:id="item_42"');
+    });
+
+    it('should roundtrip xmi:id through load and save', () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<test:Item xmlns:xmi="http://www.omg.org/XMI" xmi:version="2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:test="http://test.com/model" xmi:id="abc123"/>
+`;
+      const pkg = new BasicEPackage();
+      pkg.setName('test');
+      pkg.setNsURI('http://test.com/model');
+      pkg.setNsPrefix('test');
+
+      const eClass = new BasicEClass();
+      eClass.setName('Item');
+      pkg.getEClassifiers().push(eClass);
+
+      const resourceSet = new BasicResourceSet();
+      resourceSet.getPackageRegistry().set('http://test.com/model', pkg);
+
+      const resource = new XMIResource(URI.createURI('test://model.xmi'));
+      resource.setResourceSet(resourceSet);
+      resource.loadFromString(xml);
+
+      const obj = resource.getContents()[0];
+      expect(resource.getID(obj)).toBe('abc123');
+
+      const savedXml = resource.saveToString();
+      expect(savedXml).toContain('xmi:id="abc123"');
+    });
   });
 
   /**


### PR DESCRIPTION
## Summary
- Add `saveID()` method to `XMLSave` that writes ID attributes via `helper.getID(obj)`, matching Java EMF's `XMLSaveImpl.saveElementID()` architecture
- Add `getID(obj)` to `XMLHelper` interface / `XMLHelperImpl`, delegating to `XMLResource.getID()` (typed via `import type`)
- Configurable `idAttributeName`: default `"id"` in `XMLSave`, overridden to `"xmi:id"` in `XMISave` — matching `XMLSaveImpl` / `XMISaveImpl`
- Call `saveID()` from both `saveObject()` and `writeElement()`

Closes #46

## Test plan
- [x] New test: `should write xmi:id attributes during save` — verifies IDs set via `resource.setID()` appear in output
- [x] New test: `should roundtrip xmi:id through load and save` — verifies load→save preserves `xmi:id`
- [x] All 320 existing tests pass