### PR TITLE
fix: support @feature.index URI fragment format (#62)

### DIFF
--- a/src/runtime/BasicResource.ts
+++ b/src/runtime/BasicResource.ts
@@ -129,14 +129,17 @@ export class BasicResource implements Resource, Notifier {
       let startIndex = 0;
 
       if (isDoubleSlash) {
-        // For '//Name' fragments: start with root object and search in its contents
-        // This is how EMF handles named element navigation (like //SortOrder in an EPackage)
+        // For '//' fragments: start with root object
         current = this.contents.size() > 0 ? this.contents.get(0) : null;
         if (!current) {
           return null;
         }
-        // Now search for the first part in the root's eContents()
-        current = this.findByNameInContents(current, parts[0]);
+        // Handle @feature.index on root object, or search by name
+        if (parts[0].startsWith('@')) {
+          current = this.eObjectForURIFragmentSegment(current, parts[0]);
+        } else {
+          current = this.findByNameInContents(current, parts[0]);
+        }
         startIndex = 1;
 
         if (!current) {
@@ -237,6 +240,11 @@ export class BasicResource implements Resource, Notifier {
    * Navigate from an object to a child by name or feature.
    */
   private navigateByNameOrFeature(obj: EObject, nameOrFeature: string): EObject | null {
+    // Handle EMF @feature.index format (e.g., @ownedElement.5, @eClassifiers.0)
+    if (nameOrFeature.startsWith('@')) {
+      return this.eObjectForURIFragmentSegment(obj, nameOrFeature);
+    }
+
     // First try to find in direct contents by name
     const contents = obj.eContents();
     const byName = this.findByName(contents, nameOrFeature);
@@ -257,6 +265,63 @@ export class BasicResource implements Resource, Notifier {
       }
     }
 
+    return null;
+  }
+
+  /**
+   * Resolve a @feature.index URI fragment segment (Java EMF format).
+   * Formats:
+   * - @featureName.index → eGet(feature)[index] (multi-valued)
+   * - @featureName → eGet(feature) (single-valued)
+   */
+  private eObjectForURIFragmentSegment(obj: EObject, segment: string): EObject | null {
+    // Strip leading @
+    const body = segment.substring(1);
+    const eClass = obj.eClass();
+
+    const lastChar = body.charAt(body.length - 1);
+    let featureName: string;
+    let index = -1;
+
+    // If last char is a digit, look for .index suffix
+    if (lastChar >= '0' && lastChar <= '9') {
+      const dotIndex = body.lastIndexOf('.');
+      if (dotIndex > 0) {
+        const possibleIndex = parseInt(body.substring(dotIndex + 1), 10);
+        if (!isNaN(possibleIndex)) {
+          featureName = body.substring(0, dotIndex);
+          index = possibleIndex;
+        } else {
+          featureName = body;
+        }
+      } else {
+        featureName = body;
+      }
+    } else {
+      featureName = body;
+    }
+
+    const feature = eClass.getEStructuralFeature(featureName);
+    if (!feature) return null;
+
+    const value = obj.eGet(feature);
+    if (value === null || value === undefined) return null;
+
+    if (index >= 0) {
+      // Multi-valued: access by index
+      if (Array.isArray(value)) {
+        return (value[index] as EObject) ?? null;
+      }
+      if (typeof value === 'object' && 'get' in value && typeof (value as any).get === 'function') {
+        return ((value as any).get(index) as EObject) ?? null;
+      }
+      return null;
+    }
+
+    // Single-valued
+    if (typeof value === 'object' && 'eClass' in value) {
+      return value as EObject;
+    }
     return null;
   }
 

--- a/src/xmi/XMLHandler.ts
+++ b/src/xmi/XMLHandler.ts
@@ -920,6 +920,7 @@ export class XMLHandler {
       if (resolved) {
         this.helper.setValue(ref.object, ref.feature, resolved, ref.position);
       } else {
+        console.warn(`[XMLHandler] Forward ref UNRESOLVED: '${ref.value}' on feature '${ref.feature?.getName?.()}'`);
         // Create a proxy for unresolved reference
         const proxy = this.createProxy(ref.feature as EReference, ref.value);
         if (proxy) {

--- a/tests/XMILoad.test.ts
+++ b/tests/XMILoad.test.ts
@@ -834,4 +834,49 @@ describe('XMI Loading with Nested Elements', () => {
     expect(tsType).not.toBeNull();
     expect(tsType.getName()).toBe('DateTime');
   });
+
+  describe('@feature.index fragment resolution (#62)', () => {
+    it('should resolve @feature.index URI fragments', () => {
+      const ecoreXML = `<?xml version="1.0" encoding="UTF-8"?>
+<ecore:EPackage xmlns:xmi="http://www.omg.org/XMI" xmi:version="2.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore"
+    name="testpkg" nsURI="http://test/pkg" nsPrefix="tp">
+  <eClassifiers xsi:type="ecore:EClass" name="Parent">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="age"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Child">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="label"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+  </eClassifiers>
+</ecore:EPackage>`;
+
+      const resource = new XMIResource(URI.createURI('test.ecore'));
+      resource.setResourceSet(resourceSet);
+      resource.loadFromString(ecoreXML);
+
+      // Test @eClassifiers.0 → first classifier (Parent)
+      const parent = resource.getEObject('//@eClassifiers.0');
+      expect(parent).not.toBeNull();
+      expect((parent as any).getName()).toBe('Parent');
+
+      // Test @eClassifiers.1 → second classifier (Child)
+      const child = resource.getEObject('//@eClassifiers.1');
+      expect(child).not.toBeNull();
+      expect((child as any).getName()).toBe('Child');
+
+      // Test nested: @eClassifiers.0/@eStructuralFeatures.1 → "age" attribute
+      const ageAttr = resource.getEObject('//@eClassifiers.0/@eStructuralFeatures.1');
+      expect(ageAttr).not.toBeNull();
+      expect((ageAttr as any).getName()).toBe('age');
+
+      // Test cross-reference using @feature.index format
+      const nameAttr = resource.getEObject('//@eClassifiers.0/@eStructuralFeatures.0');
+      expect(nameAttr).not.toBeNull();
+      expect((nameAttr as any).getName()).toBe('name');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- BasicResource.getEObject() now resolves EMF-style @feature.index URI fragments
- Parses @ prefix, feature name, and optional .index suffix
- Matches Java EMF BasicEObjectImpl.eObjectForURIFragmentSegment()
- Also includes proxy URI deresolve fix for same-resource references

Closes #62

## Test plan

- 351 tests pass
- npm run build clean