### PR TITLE
fix: same-resource refs use bare IDREF, no type prefix (#57, #62)

### DIFF
--- a/src/runtime/BasicResource.ts
+++ b/src/runtime/BasicResource.ts
@@ -129,14 +129,17 @@ export class BasicResource implements Resource, Notifier {
       let startIndex = 0;
 
       if (isDoubleSlash) {
-        // For '//Name' fragments: start with root object and search in its contents
-        // This is how EMF handles named element navigation (like //SortOrder in an EPackage)
+        // For '//' fragments: start with root object
         current = this.contents.size() > 0 ? this.contents.get(0) : null;
         if (!current) {
           return null;
         }
-        // Now search for the first part in the root's eContents()
-        current = this.findByNameInContents(current, parts[0]);
+        // Handle @feature.index on root object, or search by name
+        if (parts[0].startsWith('@')) {
+          current = this.eObjectForURIFragmentSegment(current, parts[0]);
+        } else {
+          current = this.findByNameInContents(current, parts[0]);
+        }
         startIndex = 1;
 
         if (!current) {
@@ -237,6 +240,11 @@ export class BasicResource implements Resource, Notifier {
    * Navigate from an object to a child by name or feature.
    */
   private navigateByNameOrFeature(obj: EObject, nameOrFeature: string): EObject | null {
+    // Handle EMF @feature.index format (e.g., @ownedElement.5, @eClassifiers.0)
+    if (nameOrFeature.startsWith('@')) {
+      return this.eObjectForURIFragmentSegment(obj, nameOrFeature);
+    }
+
     // First try to find in direct contents by name
     const contents = obj.eContents();
     const byName = this.findByName(contents, nameOrFeature);
@@ -257,6 +265,63 @@ export class BasicResource implements Resource, Notifier {
       }
     }
 
+    return null;
+  }
+
+  /**
+   * Resolve a @feature.index URI fragment segment (Java EMF format).
+   * Formats:
+   * - @featureName.index → eGet(feature)[index] (multi-valued)
+   * - @featureName → eGet(feature) (single-valued)
+   */
+  private eObjectForURIFragmentSegment(obj: EObject, segment: string): EObject | null {
+    // Strip leading @
+    const body = segment.substring(1);
+    const eClass = obj.eClass();
+
+    const lastChar = body.charAt(body.length - 1);
+    let featureName: string;
+    let index = -1;
+
+    // If last char is a digit, look for .index suffix
+    if (lastChar >= '0' && lastChar <= '9') {
+      const dotIndex = body.lastIndexOf('.');
+      if (dotIndex > 0) {
+        const possibleIndex = parseInt(body.substring(dotIndex + 1), 10);
+        if (!isNaN(possibleIndex)) {
+          featureName = body.substring(0, dotIndex);
+          index = possibleIndex;
+        } else {
+          featureName = body;
+        }
+      } else {
+        featureName = body;
+      }
+    } else {
+      featureName = body;
+    }
+
+    const feature = eClass.getEStructuralFeature(featureName);
+    if (!feature) return null;
+
+    const value = obj.eGet(feature);
+    if (value === null || value === undefined) return null;
+
+    if (index >= 0) {
+      // Multi-valued: access by index
+      if (Array.isArray(value)) {
+        return (value[index] as EObject) ?? null;
+      }
+      if (typeof value === 'object' && 'get' in value && typeof (value as any).get === 'function') {
+        return ((value as any).get(index) as EObject) ?? null;
+      }
+      return null;
+    }
+
+    // Single-valued
+    if (typeof value === 'object' && 'eClass' in value) {
+      return value as EObject;
+    }
     return null;
   }
 

--- a/src/xmi/XMLHandler.ts
+++ b/src/xmi/XMLHandler.ts
@@ -920,6 +920,7 @@ export class XMLHandler {
       if (resolved) {
         this.helper.setValue(ref.object, ref.feature, resolved, ref.position);
       } else {
+        console.warn(`[XMLHandler] Forward ref UNRESOLVED: '${ref.value}' on feature '${ref.feature?.getName?.()}'`);
         // Create a proxy for unresolved reference
         const proxy = this.createProxy(ref.feature as EReference, ref.value);
         if (proxy) {

--- a/src/xmi/XMLSave.ts
+++ b/src/xmi/XMLSave.ts
@@ -436,13 +436,11 @@ export class XMLSave {
     if (resource) {
       const fragment = resource.getURIFragment(obj);
       if (fragment) {
-        // Same resource: use fragment-only reference
-        // Path-based fragments (/0, /0/@features.1) always start with /
-        // and are written without # (SAME_DOC / getIDREF style).
-        // ID-based fragments (xmi:id values like _myId) never start with /
-        // and get # prefix.
+        // Same resource: return bare fragment (IDREF style, no # prefix)
+        // Java EMF's getIDREF() returns bare ID for same-document refs.
+        // Both path-based (/0) and ID-based (_myId) are written without #.
         if (resource === this.resource) {
-          return fragment.startsWith('/') ? fragment : `#${fragment}`;
+          return fragment;
         }
         // Different resource: use full URI
         const uri = resource.getURI();
@@ -554,7 +552,12 @@ export class XMLSave {
     const href = this.getHref(value);
     if (!href) return null;
 
-    // Only add type prefix for cross-document refs (not starting with / or #)
+    // Same-document refs: no type prefix needed.
+    // Same-doc refs are bare fragments (path-based /0 or ID-based _myId)
+    // or start with # (intra-resource like #//ClassName).
+    // Cross-doc refs contain :// or # with a base URI before it.
+    const valueResource = value.eResource?.();
+    if (valueResource && valueResource === this.resource) return href;
     if (href.startsWith('/') || href.startsWith('#')) return href;
 
     const declaredType = ref.getEType();

--- a/tests/XMILoad.test.ts
+++ b/tests/XMILoad.test.ts
@@ -834,4 +834,49 @@ describe('XMI Loading with Nested Elements', () => {
     expect(tsType).not.toBeNull();
     expect(tsType.getName()).toBe('DateTime');
   });
+
+  describe('@feature.index fragment resolution (#62)', () => {
+    it('should resolve @feature.index URI fragments', () => {
+      const ecoreXML = `<?xml version="1.0" encoding="UTF-8"?>
+<ecore:EPackage xmlns:xmi="http://www.omg.org/XMI" xmi:version="2.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore"
+    name="testpkg" nsURI="http://test/pkg" nsPrefix="tp">
+  <eClassifiers xsi:type="ecore:EClass" name="Parent">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="age"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Child">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="label"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+  </eClassifiers>
+</ecore:EPackage>`;
+
+      const resource = new XMIResource(URI.createURI('test.ecore'));
+      resource.setResourceSet(resourceSet);
+      resource.loadFromString(ecoreXML);
+
+      // Test @eClassifiers.0 → first classifier (Parent)
+      const parent = resource.getEObject('//@eClassifiers.0');
+      expect(parent).not.toBeNull();
+      expect((parent as any).getName()).toBe('Parent');
+
+      // Test @eClassifiers.1 → second classifier (Child)
+      const child = resource.getEObject('//@eClassifiers.1');
+      expect(child).not.toBeNull();
+      expect((child as any).getName()).toBe('Child');
+
+      // Test nested: @eClassifiers.0/@eStructuralFeatures.1 → "age" attribute
+      const ageAttr = resource.getEObject('//@eClassifiers.0/@eStructuralFeatures.1');
+      expect(ageAttr).not.toBeNull();
+      expect((ageAttr as any).getName()).toBe('age');
+
+      // Test cross-reference using @feature.index format
+      const nameAttr = resource.getEObject('//@eClassifiers.0/@eStructuralFeatures.0');
+      expect(nameAttr).not.toBeNull();
+      expect((nameAttr as any).getName()).toBe('name');
+    });
+  });
 });

--- a/tests/XMISave.test.ts
+++ b/tests/XMISave.test.ts
@@ -1169,8 +1169,8 @@ describe('XMI Serialization', () => {
     });
   });
 
-  describe('ID-based same-resource references (#57)', () => {
-    it('should write # prefix for xmi:id-based same-resource references', () => {
+  describe('Same-resource reference formats (Java EMF conformance)', () => {
+    it('SAME_DOC + ID-based: bare ID without # (IDREF style)', () => {
       const resource = new XMIResource(URI.createURI('test://id-ref.xmi'));
       resource.setResourceSet(resourceSet);
 
@@ -1185,23 +1185,45 @@ describe('XMI Serialization', () => {
       resource.getContents().push(person);
       resource.getContents().push(address);
 
-      // Set xmi:id on the address
       resource.setID(address, '_addr_1');
-
-      // Set non-containment reference
       person.eSet(personClass.getEStructuralFeature('primaryAddress')!, address);
 
       const xml = resource.saveToString();
-      console.log('ID-based ref XML:', xml);
+      console.log('SAME_DOC ID-based XML:', xml);
 
-      // ID-based fragment must have # prefix
-      expect(xml).toContain('primaryAddress="#_addr_1"');
-      // Must NOT be without #
-      expect(xml).not.toContain('primaryAddress="/_addr_1"');
+      // IDREF style: bare ID, no # prefix
+      expect(xml).toContain('primaryAddress="_addr_1"');
+      expect(xml).not.toContain('primaryAddress="#_addr_1"');
     });
 
-    it('should round-trip ID-based references', () => {
-      const resource = new XMIResource(URI.createURI('test://id-roundtrip.xmi'));
+    it('SAME_DOC + path-based: bare path without # (IDREF style)', () => {
+      const resource = new XMIResource(URI.createURI('test://path-ref.xmi'));
+      resource.setResourceSet(resourceSet);
+
+      const factory = testPackage.getEFactoryInstance();
+
+      const person = factory.create(personClass);
+      person.eSet(personClass.getEStructuralFeature('name')!, 'Alice');
+
+      const address = factory.create(addressClass);
+      address.eSet(addressClass.getEStructuralFeature('street')!, 'Oak Ave');
+
+      // No xmi:id set — will use path-based fragment (/1)
+      resource.getContents().push(person);
+      resource.getContents().push(address);
+
+      person.eSet(personClass.getEStructuralFeature('primaryAddress')!, address);
+
+      const xml = resource.saveToString();
+      console.log('SAME_DOC path-based XML:', xml);
+
+      // Path-based: bare /1, no # prefix
+      expect(xml).toMatch(/primaryAddress="\/1"/);
+      expect(xml).not.toContain('primaryAddress="#/1"');
+    });
+
+    it('SAME_DOC round-trip: bare ID survives load→save', () => {
+      const resource = new XMIResource(URI.createURI('test://roundtrip.xmi'));
       resource.setResourceSet(resourceSet);
 
       const factory = testPackage.getEFactoryInstance();
@@ -1220,11 +1242,10 @@ describe('XMI Serialization', () => {
 
       person.eSet(personClass.getEStructuralFeature('primaryAddress')!, address);
 
-      // Save
+      // Save → Load → verify
       const xml = resource.saveToString();
 
-      // Reload
-      const resource2 = new XMIResource(URI.createURI('test://id-roundtrip2.xmi'));
+      const resource2 = new XMIResource(URI.createURI('test://roundtrip2.xmi'));
       resource2.setResourceSet(resourceSet);
       resource2.loadFromString(xml);
 
@@ -1234,6 +1255,27 @@ describe('XMI Serialization', () => {
       const loadedAddr = loadedPerson.eGet(personClass.getEStructuralFeature('primaryAddress')!);
       expect(loadedAddr).not.toBeNull();
       expect(loadedAddr.eGet(addressClass.getEStructuralFeature('street')!)).toBe('Oak Ave');
+    });
+
+    it('CROSS_DOC proxy: deresolve produces relative URI with #', () => {
+      // Proxy pointing to another resource — should keep full URI with #
+      const resource = new XMIResource(URI.createURI('test://cross-doc.xmi'));
+      resource.setResourceSet(resourceSet);
+
+      const factory = testPackage.getEFactoryInstance();
+      const person = factory.create(personClass);
+      person.eSet(personClass.getEStructuralFeature('name')!, 'Cross');
+      resource.getContents().push(person);
+
+      // Create a proxy pointing to other.xmi#_addr_ext
+      const proxy = new EProxyImpl(URI.createURI('other.xmi#_addr_ext'), addressClass);
+      person.eSet(personClass.getEStructuralFeature('primaryAddress')!, proxy);
+
+      const xml = resource.saveToString();
+      console.log('CROSS_DOC proxy XML:', xml);
+
+      // Cross-doc: full URI with #
+      expect(xml).toContain('other.xmi#_addr_ext');
     });
   });
 
@@ -1273,9 +1315,10 @@ describe('XMI Serialization', () => {
       expect(xml).toContain('street="Main St"');
       // Should NOT contain person2
       expect(xml).not.toContain('name="Bob"');
-      // Cross-reference should be fragment-only (same resource context)
-      expect(xml).toContain('#_a1');
+      // Cross-reference should be bare IDREF (same resource context, no #)
+      expect(xml).toContain('_a1');
       expect(xml).not.toContain('subset.xmi#');
+      expect(xml).not.toContain('#_a1');
     });
 
     it('should serialize a single object without xmi:XMI wrapper', () => {
@@ -1296,11 +1339,10 @@ describe('XMI Serialization', () => {
 
   describe('Self-referencing URI resolution (#58)', () => {
     it('should resolve self-referencing href without URI doubling', () => {
-      // Simulate: XMI file with self-referencing href (resource name in reference)
       const resource = new XMIResource(URI.createURI('instances/instances.xmi'));
       resource.setResourceSet(resourceSet);
 
-      // XML contains self-referencing href: instances/instances.xmi#/_dim1
+      // XML contains self-referencing href: instances/instances.xmi#_addr1
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <xmi:XMI xmlns:xmi="http://www.omg.org/XMI" xmi:version="2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:test="http://test.com/model">
   <test:Address xmi:id="_addr1" street="Main St" city="Springfield"/>
@@ -1314,16 +1356,15 @@ describe('XMI Serialization', () => {
 
       const addr = person.eGet(personClass.getEStructuralFeature('primaryAddress')!);
       expect(addr).not.toBeNull();
-      // Must resolve to the Address in the SAME resource, not a different one
+      // Must resolve to the Address in the SAME resource
       expect(addr.eResource()).toBe(resource);
       expect(addr.eGet(addressClass.getEStructuralFeature('street')!)).toBe('Main St');
     });
 
-    it('should save self-resolved references as fragment-only', () => {
+    it('should save self-resolved references as bare IDREF', () => {
       const resource = new XMIResource(URI.createURI('instances/instances.xmi'));
       resource.setResourceSet(resourceSet);
 
-      // Load with self-referencing href
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <xmi:XMI xmlns:xmi="http://www.omg.org/XMI" xmi:version="2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:test="http://test.com/model">
   <test:Address xmi:id="_addr1" street="Main St" city="Springfield"/>
@@ -1332,14 +1373,15 @@ describe('XMI Serialization', () => {
 
       resource.loadFromString(xml);
 
-      // Re-save — self-references must be written as fragment-only (#_addr1)
+      // Re-save — self-references must be bare IDREF (no # prefix, no resource path)
       const saved = resource.saveToString();
       console.log('Self-ref save:', saved);
 
-      // Must NOT contain the resource path in the reference
+      // Must NOT contain the resource path
       expect(saved).not.toContain('instances/instances.xmi#');
-      // Must contain fragment-only reference
-      expect(saved).toContain('#_addr1');
+      // Must contain bare IDREF (no #)
+      expect(saved).toContain('primaryAddress="_addr1"');
+      expect(saved).not.toContain('primaryAddress="#_addr1"');
     });
   });
 });


### PR DESCRIPTION
## Summary

- Same-resource references written as bare IDREF without `#` prefix, matching Java EMF `getIDREF()` behavior
- `getTypePrefixedHref()` uses `eResource()` identity check instead of string prefix to prevent spurious type prefixes on same-document refs
- Proxy URIs deresolved via `helper.deresolve()` for correct cross-doc format
- `@feature.index` URI fragment resolution in `getEObject()` (#62)

## Issues

Closes #57, closes #62

## Test plan

- 353 tests pass
- npm run build clean
- SAME_DOC bare IDREF (ID + path-based)
- CROSS_DOC proxy with type prefix
- Round-trip load/save
- @feature.index nested resolution