### PR TITLE
fix: eGenericType loading, typed nested elements, registry API and EList array compatibility (#65, #66, #67, #68)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, snapshot]
   pull_request:
-    branches: [main]
+    branches: [main, snapshot]
 
 jobs:
   build:

--- a/BUG-eAnnotation-details-push.md
+++ b/BUG-eAnnotation-details-push.md
@@ -1,0 +1,55 @@
+# Bug: BasicEAnnotation.eGet('details') returns Map — XMI loader crash
+
+## Fehler
+
+```
+TypeError: list.push is not a function
+    at XMLHelperImpl.setValue (XMLHelper.js:252:22)
+    at XMIHandler.createObject (XMLHandler.js:514:25)
+    at XMIHandler.handleFeature (XMLHandler.js:438:22)
+```
+
+## Ursache
+
+`EcoreFactory.create()` wurde um `case 'EAnnotation': return new BasicEAnnotation()` erweitert (Commit auf `src/ecore/EcorePackage.ts`). Vorher wurde ein `DynamicEObject` erzeugt, dessen `eGet` fuer many-Features ein Array zurueckgibt.
+
+`BasicEAnnotation.eGet('details')` gibt `this.details` zurueck — eine `Map<string, string>`. Der XMI Loader (`XMLHelper.setValue`) erwartet aber ein Array mit `.push()`:
+
+```typescript
+// XMLHelper.ts:344-353
+setValue(eObject, feature, value, position) {
+  if (feature.isMany()) {
+    let list = eObject.eGet(feature);  // Map<string, string> ← kein Array!
+    if (!list) { list = []; eObject.eSet(feature, list); }
+    list.push(value);                  // ← TypeError: Map hat kein .push()
+  }
+}
+```
+
+## Reproduktion
+
+Jede `.ecore` Datei mit `<details>` Kindelementen in `<eAnnotations>`:
+
+```xml
+<eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+  <details key="documentation" value="..."/>
+</eAnnotations>
+```
+
+## Java EMF Verhalten
+
+In Java EMF gibt `EAnnotation.getDetails()` ein `EMap<String, String>` zurueck, das `EList` erweitert. `EMap` unterstuetzt sowohl Listen-Operationen (`add()`) als auch Map-Operationen (`get(key)`, `put(key, value)`). `eGet(detailsFeature)` gibt dasselbe `EMap`-Objekt zurueck.
+
+## Vorgeschlagener Fix
+
+Option A: `eGet('details')` ein Array von EStringToStringMapEntry-EObjects zurueckgeben lassen (XMI-kompatibel), `getDetails()` synchronisiert lazy in die Map.
+
+Option B: Eine `EMap`-Implementierung erstellen die sowohl `push()`/Array-Kompatibilitaet als auch `Map.get()`/`Map.set()` bietet (analog zu Java EMF).
+
+Option C: `XMLHelper.setValue` um Map-Handling erweitern — wenn `list instanceof Map`, die Map-Entry Attribute (`key`/`value`) extrahieren und `map.set()` aufrufen. Erfordert Aenderung der Reihenfolge in `createObject` (erst `handleObjectAttribs`, dann `setValue`).
+
+## Betroffene Dateien
+
+- `src/runtime/BasicEAnnotation.ts` — `eGet('details')` gibt Map statt Array zurueck
+- `src/xmi/XMLHelper.ts` — `setValue()` nimmt Array an
+- `src/ecore/EcorePackage.ts` — `EcoreFactory.create('EAnnotation')` erzeugt jetzt BasicEAnnotation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to the `emfts` package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Generics support when loading `.ecore` files ([#65](https://github.com/eclipse-fennec/emf.ts/issues/65)). `ETypedElement.eGenericType`, `EClassifier.eTypeParameters`, `EClass.eGenericSuperTypes`, `EOperation.eTypeParameters`, `ETypeParameter.eBounds` and the full `EGenericType` structure are part of the Ecore metamodel now, with `BasicEGenericType` and `BasicETypeParameter` implementations. A feature typed via `<eGenericType>` gets its type from the raw type of the generic type instead of ending up untyped, keeps its type arguments, and survives a save/load round trip.
+- `BasicEParameter`, and `EOperation`/`EParameter` are created through `EcoreFactory` ([#66](https://github.com/eclipse-fennec/emf.ts/issues/66)). Nested model elements arrive as typed objects rather than `DynamicEObject`, so the accessors declared on the interfaces work.
+- `registerPackage(pkg)` is part of the `EPackageRegistry` interface ([#67](https://github.com/eclipse-fennec/emf.ts/issues/67)). Previously only the registries from `src/ecore/index.ts` offered it, so registering on a `ResourceSet`'s registry meant reading the nsURI off the package by hand.
+- Array-compatible API on `EList` ([#68](https://github.com/eclipse-fennec/emf.ts/issues/68)): index signature with `list[i]` on every list however constructed, plus `concat`, `sort`, `reverse`, `join`, `at`, `lastIndexOf`, `flatMap` and `toJSON`. Index writes route through `set()`/`add()` and `sort()`/`reverse()` reorder through `move()`, so notifications are still emitted.
+- [`docs/collections.md`](./docs/collections.md) documenting which accessors return an `EList` and which a plain array, and why `Array.isArray()` on an `EList` is `false` by design.
+
+### Fixed
+
+- `BasicEOperation.getEAnnotations()` returned a hardcoded `[]` and `getEAnnotation()` always returned `null`, so annotations on an operation were unreachable.
+- `getETypeParameters()` on `BasicEClass` and `BasicEDataType` returned a hardcoded `[]`.
+- `createPackageRegistry().set()` was the only registry implementation that did not register subpackages recursively.
+- `JSON.stringify()` on an `EList` exposed the internal `data`/`owner`/`feature` fields and pulled the owning object into the output.
+
+### Changed
+
+- `registerPackage()` throws for a package without an nsURI instead of silently dropping it; the entry could never be looked up afterwards.
+- `getPackageRegistry()` returns the global registry instance directly instead of a spread copy.
+- README recommends `npm install @emfts/core@next`, since `latest` is still `0.1.0` and predates the `@masagroup/ecore` compatibility layer.
+
+### Notes
+
+- The accessors that return plain arrays (`getEOperations()`, `getESuperTypes()`, `getEAll*()`, `getEAnnotations()`) are **not** unified onto `EList` in this release. That changes public return types and is planned for a major version; the additions above are the groundwork.
+
 ## [1.0.1] - 2026-02-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the `emfts` package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.1-next.17] - 2026-08-14
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@ This package provides a TypeScript implementation of the Eclipse Modeling Framew
 
 The Ecore metamodel aligns with the OMG [Meta Object Facility (MOF)](https://www.omg.org/spec/MOF/) — specifically EMOF (Essential MOF).
 
+## Installation
+
+```bash
+npm install @emfts/core@next
+```
+
+> **Use the `next` tag for now.** The `latest` tag still points at `0.1.0`, which
+> predates a substantial part of the runtime. In particular the `@masagroup/ecore`
+> compatibility layer under `src/ecore/` — `EResourceSetImpl` with the XMI factory
+> pre-registered for `.ecore`, `getEcorePackage()`, the package registries — exists
+> only in `next`. If you are migrating from `@masagroup/ecore`, that layer is what
+> you want, and `npm install @emfts/core` alone will not give it to you.
+
 ## Core Interfaces
 
 ### Metamodel Hierarchy
@@ -68,6 +81,14 @@ console.log(name); // 'John Doe'
 - ✅ Package registry pattern
 - ✅ Factory pattern for object creation
 
+## Documentation
+
+- [Collections: EList, EMap and arrays](./docs/collections.md) — which accessors
+  return an `EList` and which return a plain array, and why `Array.isArray()` is
+  `false` on an `EList`
+- [Examples](./docs/examples/index.md) — dynamic models, factories, notifications,
+  XMI/JSON persistence
+
 ## Architecture
 
 The interfaces follow the same design as Eclipse EMF:
@@ -90,9 +111,10 @@ npm run build
 |---|---|
 | Registry | [npmjs.com](https://www.npmjs.com/package/@emfts/core) |
 | Package | [`@emfts/core`](https://www.npmjs.com/package/@emfts/core) (public) |
-| Install | `npm install @emfts/core` |
+| Install | `npm install @emfts/core@next` (see [Installation](#installation)) |
+| Dist-tags | `next` — current development line · `latest` — `0.1.0`, predates the `@masagroup/ecore` compatibility layer |
 | Build output | `dist/` (ESM, `tsc`) — only `dist` is published (see `files` in `package.json`) |
-| Source | <https://github.com/eclipse-fennec/emf.ts> (default branch `main`) |
+| Source | <https://github.com/eclipse-fennec/emf.ts> (default branch `snapshot`) |
 | Project | [Eclipse Fennec](https://projects.eclipse.org/projects/modeling.fennec) |
 
 Releases are published to the npm registry under the `@emfts` scope.

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -1,0 +1,126 @@
+# Collections: EList, EMap and arrays
+
+Multi-valued features are returned either as an `EList` or as a plain array,
+depending on the accessor. This page says which is which, and what an `EList`
+guarantees that an array cannot.
+
+## Which accessor returns what
+
+`EList` accessors are the ones that own their contents: mutating them updates the
+model and emits notifications. Array accessors are either derived views
+(`getEAll*`, filtered variants) or lists that have not been migrated yet.
+
+| Accessor | Returns |
+|---|---|
+| `EPackage.getEClassifiers()` | `EList<EClassifier>` |
+| `EPackage.getESubpackages()` | `EList<EPackage>` |
+| `EClass.getEStructuralFeatures()` | `EList<EStructuralFeature>` |
+| `Resource.getContents()` | `EList<EObject>` |
+| `EAnnotation.getDetails()` | `EMap<string, string>` |
+| `EClass.getESuperTypes()` | `EClass[]` |
+| `EClass.getEAllSuperTypes()` | `EClass[]` |
+| `EClass.getEAllStructuralFeatures()` | `EStructuralFeature[]` |
+| `EClass.getEAttributes()` / `getEAllAttributes()` | `EAttribute[]` |
+| `EClass.getEReferences()` / `getEAllReferences()` | `EReference[]` |
+| `EClass.getEAllContainments()` | `EReference[]` |
+| `EClass.getEOperations()` / `getEAllOperations()` | `EOperation[]` |
+| `EClassifier.getETypeParameters()` | `ETypeParameter[]` |
+| `EOperation.getEParameters()` | `EParameter[]` |
+| `EOperation.getEExceptions()` | `EClassifier[]` |
+| `EEnum.getELiterals()` | `EEnumLiteral[]` |
+| `EModelElement.getEAnnotations()` | `EAnnotation[]` |
+| `EAnnotation.getContents()` / `getReferences()` | `EObject[]` |
+| `ETypeParameter.getEBounds()` | `EGenericType[]` |
+| `EGenericType.getETypeArguments()` | `EGenericType[]` |
+| `ResourceSet.getResources()` | `Resource[]` |
+
+Java EMF returns an `EList` throughout, so the array returns are a known
+deviation; the intent is to unify on `EList` in a future major version. Writing
+code that works with either is straightforward, because the two overlap far more
+than they differ - see below.
+
+## Writing code that works with both
+
+An `EList` supports the array API you are likely to reach for:
+
+```ts
+list.length          // and size()
+list[0]              // and get(0)
+list.map(fn)         // filter, forEach, find, findIndex, some, every,
+                     // slice, reduce, includes, indexOf, lastIndexOf,
+                     // concat, join, at, flatMap
+list.push(x)         // pop, shift, unshift, splice
+list.sort(cmp)       // reverse
+for (const x of list) { /* ... */ }
+const [first] = list
+const copy = [...list]
+JSON.stringify(list) // -> [...]
+```
+
+Two idioms need care:
+
+```ts
+// Works on an EList, but NOT on an array:
+list.size()
+
+// Works on an array, but NOT on an EList:
+Array.isArray(value)
+```
+
+If you need one shape regardless of what an accessor gave you, normalize with
+`Array.from()`, which works on both:
+
+```ts
+const features = Array.from(eClass.getEAllStructuralFeatures())
+```
+
+## EList is not an Array - deliberately
+
+`Array.isArray(eList)` returns `false`, and that will not change.
+
+An `EList` is a `NotifyingEList`: every mutation emits a notification, which is
+what adapters and `EContentAdapter` rely on. A real Array cannot keep that
+promise, because it exposes two write paths that no interceptor can see:
+
+```ts
+list.length = 0      // would empty the list
+list[5] = value      // would write a raw slot
+```
+
+`EList` supports both of these expressions, but routes them through `clear()`,
+`removeAt()` and `set()` so that notifications still fire. Inheriting from
+`Array` would hand out the native versions instead and silently break the
+contract. Array subclasses also construct their own type via `Symbol.species`,
+so `map()` and `filter()` would try to build an `EList` with an array length as
+its constructor argument.
+
+This is the position `NodeList`, `HTMLCollection`, `FileList` and `arguments`
+have held in the DOM for decades: indexable, iterable, with a `length` - and not
+an array. `Array.from(list)` is the documented way to get a real one.
+
+Note that assigning past the end throws instead of creating a sparse list:
+
+```ts
+const list = eClass.getEStructuralFeatures()  // size 2
+list[2] = feature   // appends, same as add()
+list[7] = feature   // RangeError - use add() or push()
+```
+
+## Serialization
+
+`JSON.stringify(list)` produces a plain array. This works for lists of primitive
+values; a list of `EObject`s still cannot be stringified directly, because
+`EObject`s reference their container and are therefore cyclic. Use the JSON
+resource support for models - see [examples/Persistence.md](./examples/Persistence.md).
+
+## EMap
+
+`EAnnotation.getDetails()` returns an `EMap<K, V>`, which is an `EList` of map
+entries plus map operations (`getByKey`, `putByKey`, `removeByKey`,
+`containsKey`, `keys`, `mapValues`, `toMap`). This mirrors Java EMF, where
+`EMap<K,V>` extends `EList<Map.Entry<K,V>>`.
+
+Because `EMap.keys()` returns the map keys, `EList` deliberately does not declare
+the array-style `keys()`/`values()`/`entries()` iterators - the two meanings
+cannot coexist on one type. Use `Array.from(list).keys()` if you need the
+array-style iterator.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "emfts",
-  "version": "1.0.0",
+  "version": "0.1.1-next.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "emfts",
-      "version": "1.0.0",
+      "version": "0.1.1-next.17",
       "license": "EPL-2.0",
       "devDependencies": {
         "@commitlint/cli": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emfts/core",
-  "version": "0.1.1-next.3",
+  "version": "0.1.1-next.17",
   "description": "TypeScript interfaces for Eclipse EMF Core",
   "type": "module",
   "main": "dist/index.js",

--- a/src/EList.ts
+++ b/src/EList.ts
@@ -15,8 +15,22 @@ import { Notification, NotificationImpl, NotificationType, NotificationEventType
 /**
  * EList interface - A list that sends notifications on modifications.
  * This mirrors Java EMF's EList interface.
+ *
+ * An EList is indexable and iterable, but it is deliberately **not** an Array:
+ * `Array.isArray(eList)` returns `false`. The list guarantees that every
+ * mutation emits a notification, which a real Array cannot do - inheriting from
+ * Array would expose the `length` setter and raw index assignment, both of
+ * which bypass every interceptor. This mirrors the position of `NodeList` and
+ * `HTMLCollection` in the DOM. Use `Array.from(list)` when a real Array is
+ * required.
  */
 export interface EList<T> extends Iterable<T> {
+  /**
+   * Array-compatible index access. Reads return the element at the index,
+   * writes are routed through {@link set} so notifications are still sent.
+   */
+  [index: number]: T;
+
   /**
    * Returns the number of elements in the list.
    */
@@ -160,6 +174,52 @@ export interface EList<T> extends Iterable<T> {
    * Array-compatible slice method.
    */
   slice(start?: number, end?: number): T[];
+
+  /**
+   * Array-compatible concat method. Does not modify the list.
+   */
+  concat(...items: (T | T[] | EList<T>)[]): T[];
+
+  /**
+   * Array-compatible sort method. Sorts the list in place and returns it.
+   * Emits a MOVE notification per relocated element, like ECollections.sort().
+   */
+  sort(compareFn?: (a: T, b: T) => number): this;
+
+  /**
+   * Array-compatible reverse method. Reverses the list in place and returns it.
+   */
+  reverse(): this;
+
+  /**
+   * Array-compatible join method.
+   */
+  join(separator?: string): string;
+
+  /**
+   * Array-compatible at method. Supports negative indices.
+   */
+  at(index: number): T | undefined;
+
+  /**
+   * Array-compatible lastIndexOf method.
+   */
+  lastIndexOf(element: T): number;
+
+  /**
+   * Array-compatible flatMap method.
+   */
+  flatMap<U>(callback: (value: T, index: number, array: T[]) => U | U[], thisArg?: any): U[];
+
+  // NOTE: keys()/values()/entries() are deliberately absent. EMap extends
+  // EList and defines keys() with Map semantics (returning the map keys), so an
+  // Array-style keys() cannot coexist. Use Array.from(list).keys() if needed.
+
+  /**
+   * Serializes as a plain array, so `JSON.stringify(list)` yields `[...]`
+   * instead of exposing the internal structure (and dragging the owner along).
+   */
+  toJSON(): T[];
 }
 
 /**
@@ -178,6 +238,86 @@ export interface NotifyingEList<T> extends EList<T> {
 }
 
 /**
+ * Matches property keys that address a list position: "0", "1", "42".
+ * Deliberately strict - "01", "1.5", "-1" and "" are not index keys.
+ */
+const INDEX_KEY = /^(?:0|[1-9]\d*)$/;
+
+/**
+ * Marks a list that is already wrapped for index access, so that
+ * createIndexedProxy() does not stack a second Proxy on top.
+ */
+const IS_INDEXED = Symbol.for('emfts.indexedList');
+
+/**
+ * Proxy handler that maps numeric property keys onto list positions.
+ * Shared by all instances; it is stateless.
+ */
+const INDEX_ACCESS_HANDLER: ProxyHandler<any> = {
+  get(target, prop, receiver) {
+    if (prop === IS_INDEXED) {
+      return true;
+    }
+    if (typeof prop === 'string' && INDEX_KEY.test(prop)) {
+      const index = Number(prop);
+      // Fast path for implementations backed by a plain array.
+      const data: any[] | undefined = target.data;
+      if (data !== undefined) {
+        return data[index];
+      }
+      // Generic path (e.g. BasicEMap, which delegates): get() throws when out
+      // of bounds, but array semantics ask for undefined.
+      return index < target.size() ? target.get(index) : undefined;
+    }
+    return Reflect.get(target, prop, receiver);
+  },
+
+  set(target, prop, value, receiver) {
+    // Array-compatible truncation: list.length = 0 clears, a smaller length
+    // drops the tail. Each removal goes through the list, so notifications are
+    // still emitted - unlike the length setter of a real Array.
+    if (prop === 'length') {
+      const newLength = typeof value === 'number' ? value : parseInt(value, 10);
+      if (isNaN(newLength) || newLength < 0) {
+        throw new RangeError(`Invalid list length: ${String(value)}`);
+      }
+      if (newLength === 0) {
+        target.clear();
+      } else {
+        while (target.size() > newLength) {
+          target.removeAt(target.size() - 1);
+        }
+      }
+      return true;
+    }
+    if (typeof prop === 'string' && INDEX_KEY.test(prop)) {
+      const index = Number(prop);
+      const size = target.size();
+      if (index < size) {
+        target.set(index, value);
+      } else if (index === size) {
+        // Appending via list[list.length] = x is a common array idiom.
+        target.add(value);
+      } else {
+        throw new RangeError(
+          `Index ${index} out of bounds for list of size ${size}. ` +
+          `ELists do not support sparse assignment - use add() or push().`
+        );
+      }
+      return true;
+    }
+    return Reflect.set(target, prop, value, receiver);
+  },
+
+  has(target, prop) {
+    if (typeof prop === 'string' && INDEX_KEY.test(prop)) {
+      return Number(prop) < target.size();
+    }
+    return Reflect.has(target, prop);
+  },
+};
+
+/**
  * Basic EList implementation that sends notifications on modifications.
  * Similar to org.eclipse.emf.ecore.util.EObjectEList in Java EMF.
  *
@@ -185,6 +325,8 @@ export interface NotifyingEList<T> extends EList<T> {
  * for backwards compatibility with code that expects arrays.
  */
 export class BasicEList<T> implements NotifyingEList<T> {
+  [index: number]: T;
+
   protected data: T[] = [];
   protected owner: EObject | null;
   protected feature: EStructuralFeature | null;
@@ -192,6 +334,12 @@ export class BasicEList<T> implements NotifyingEList<T> {
   constructor(owner: EObject | null = null, feature: EStructuralFeature | null = null) {
     this.owner = owner;
     this.feature = feature;
+
+    // Numeric index access (list[0]) is provided through a Proxy rather than by
+    // extending Array: writes are routed through set()/add() so notifications
+    // are still emitted. Returning an object from a base constructor makes it
+    // the `this` of every subclass, so all EList subclasses inherit this.
+    return new Proxy(this, INDEX_ACCESS_HANDLER) as this;
   }
 
   // ===== Array-compatible properties and methods =====
@@ -351,6 +499,101 @@ export class BasicEList<T> implements NotifyingEList<T> {
    */
   slice(start?: number, end?: number): T[] {
     return this.data.slice(start, end);
+  }
+
+  /**
+   * Array-compatible concat method. Returns a new array, list is unchanged.
+   * Accepts single values, arrays and other ELists as arguments.
+   */
+  concat(...items: (T | T[] | EList<T>)[]): T[] {
+    const result = [...this.data];
+    for (const item of items) {
+      if (Array.isArray(item)) {
+        result.push(...item);
+      } else if (item instanceof BasicEList) {
+        result.push(...(item as BasicEList<T>).data);
+      } else {
+        result.push(item as T);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Array-compatible sort method. Sorts in place and returns the list.
+   *
+   * The reordering is applied through move(), so each relocated element emits a
+   * MOVE notification. This mirrors ECollections.sort() in Java EMF rather than
+   * silently rewriting the backing array.
+   */
+  sort(compareFn?: (a: T, b: T) => number): this {
+    this.reorderTo([...this.data].sort(compareFn));
+    return this;
+  }
+
+  /**
+   * Array-compatible reverse method. Reverses in place and returns the list.
+   * Emits MOVE notifications, see {@link sort}.
+   */
+  reverse(): this {
+    this.reorderTo([...this.data].reverse());
+    return this;
+  }
+
+  /**
+   * Rearranges the list to match the given order using move(), so that every
+   * relocation is observable. The order must be a permutation of the list.
+   */
+  protected reorderTo(order: T[]): void {
+    for (let i = 0; i < order.length; i++) {
+      if (this.data[i] === order[i]) {
+        continue;
+      }
+      // Positions below i are already final, so search from i onwards.
+      const from = this.data.indexOf(order[i], i);
+      if (from > i) {
+        this.move(i, from);
+      }
+    }
+  }
+
+  /**
+   * Array-compatible join method.
+   */
+  join(separator?: string): string {
+    return this.data.join(separator);
+  }
+
+  /**
+   * Array-compatible at method. Negative indices count from the end.
+   * Implemented directly rather than via Array.prototype.at, which the ES2020
+   * target of this project does not provide.
+   */
+  at(index: number): T | undefined {
+    const resolved = index < 0 ? this.data.length + index : index;
+    return resolved >= 0 && resolved < this.data.length ? this.data[resolved] : undefined;
+  }
+
+  /**
+   * Array-compatible lastIndexOf method.
+   */
+  lastIndexOf(element: T): number {
+    return this.data.lastIndexOf(element);
+  }
+
+  /**
+   * Array-compatible flatMap method.
+   */
+  flatMap<U>(callback: (value: T, index: number, array: T[]) => U | U[], thisArg?: any): U[] {
+    return this.data.flatMap((value, index) => callback.call(thisArg, value, index, this.data));
+  }
+
+  /**
+   * Makes JSON.stringify(list) produce a plain array. Without this the internal
+   * fields would be serialized, and `owner` would drag the whole model along.
+   */
+  toJSON(): T[] {
+    return [...this.data];
   }
 
   // ===== End Array-compatible methods =====
@@ -849,54 +1092,16 @@ export function isEList<T>(obj: any): obj is EList<T> {
 
 /**
  * Wraps an EList with a Proxy to enable array-like index access (list[0], list[1], etc.)
+ *
+ * Every EList now installs this Proxy in its own constructor, so this function
+ * is a no-op for lists created by this library and is kept for compatibility
+ * with existing call sites. Lists that arrive unwrapped are still wrapped here.
  */
-export function createIndexedProxy<T, L extends BasicEList<T>>(list: L): L & { [index: number]: T } {
-  return new Proxy(list, {
-    get(target, prop, receiver) {
-      // Handle numeric index access
-      if (typeof prop === 'string') {
-        const index = parseInt(prop, 10);
-        if (!isNaN(index) && index >= 0) {
-          if (index < target.size()) {
-            return target.get(index);
-          }
-          return undefined;
-        }
-      }
-      return Reflect.get(target, prop, receiver);
-    },
-    set(target, prop, value, receiver) {
-      // Handle 'length' property for array compatibility
-      if (prop === 'length') {
-        const newLength = typeof value === 'number' ? value : parseInt(value, 10);
-        if (newLength === 0) {
-          target.clear();
-          return true;
-        }
-        // Truncate list if needed
-        while (target.size() > newLength) {
-          target.removeAt(target.size() - 1);
-        }
-        return true;
-      }
-      // Handle numeric index assignment
-      if (typeof prop === 'string') {
-        const index = parseInt(prop, 10);
-        if (!isNaN(index) && index >= 0) {
-          if (index < target.size()) {
-            target.set(index, value);
-            return true;
-          } else if (index === target.size()) {
-            target.add(value);
-            return true;
-          }
-          // Index out of bounds for assignment
-          return false;
-        }
-      }
-      return Reflect.set(target, prop, value, receiver);
-    }
-  }) as L & { [index: number]: T };
+export function createIndexedProxy<T, L extends EList<T>>(list: L): L & { [index: number]: T } {
+  if ((list as any)[IS_INDEXED]) {
+    return list as L & { [index: number]: T };
+  }
+  return new Proxy(list, INDEX_ACCESS_HANDLER) as L & { [index: number]: T };
 }
 
 /**

--- a/src/EMap.ts
+++ b/src/EMap.ts
@@ -10,7 +10,7 @@ import { EObject } from './EObject.js';
 import { EClass } from './EClass.js';
 import { EStructuralFeature } from './EStructuralFeature.js';
 import { EReference } from './EReference.js';
-import { EList, EObjectContainmentEList, BasicEList } from './EList.js';
+import { EList, EObjectContainmentEList, BasicEList, createIndexedProxy } from './EList.js';
 import { DynamicEObject } from './runtime/BasicEObject.js';
 
 /**
@@ -81,6 +81,8 @@ class EMapContainmentEList<K, V> extends EObjectContainmentEList<EObject> {
  * The map index is maintained via didAdd/didRemove callbacks from the delegate list.
  */
 export class BasicEMap<K, V> implements EMap<K, V> {
+  [index: number]: EObject;
+
   private delegateList: EMapContainmentEList<K, V>;
   private mapIndex: Map<K, EObject> | null = null;
   private keyFeature: EStructuralFeature;
@@ -100,6 +102,9 @@ export class BasicEMap<K, V> implements EMap<K, V> {
     }
     this.keyFeature = keyF;
     this.valueFeature = valueF;
+
+    // Same index-access contract as every other EList, see BasicEList.
+    return createIndexedProxy<EObject, BasicEMap<K, V>>(this) as BasicEMap<K, V>;
   }
 
   /**
@@ -255,61 +260,31 @@ export class BasicEMap<K, V> implements EMap<K, V> {
   }
   includes(element: EObject): boolean { return this.delegateList.includes(element); }
   slice(start?: number, end?: number): EObject[] { return this.delegateList.slice(start, end); }
+  concat(...items: (EObject | EObject[] | EList<EObject>)[]): EObject[] { return this.delegateList.concat(...items); }
+  sort(compareFn?: (a: EObject, b: EObject) => number): this { this.delegateList.sort(compareFn); return this; }
+  reverse(): this { this.delegateList.reverse(); return this; }
+  join(separator?: string): string { return this.delegateList.join(separator); }
+  at(index: number): EObject | undefined { return this.delegateList.at(index); }
+  lastIndexOf(element: EObject): number { return this.delegateList.lastIndexOf(element); }
+  flatMap<U>(callback: (value: EObject, index: number, array: EObject[]) => U | U[], thisArg?: any): U[] {
+    return this.delegateList.flatMap(callback, thisArg);
+  }
+  toJSON(): EObject[] { return this.delegateList.toJSON(); }
 }
 
 /**
- * Creates an EMap with a Proxy for array-like index access.
- * Unlike createIndexedProxy (which constrains on BasicEList), this
- * creates a proxy specifically for BasicEMap.
+ * Creates an EMap with array-like index access.
+ *
+ * BasicEMap installs the index-access Proxy in its own constructor, so this is
+ * a plain factory now; it is kept because it is the documented way to obtain an
+ * EMap.
  */
 export function createEMap<K, V>(
   owner: EObject,
   feature: EReference,
   entryEClass: EClass
 ): EMap<K, V> & { [index: number]: EObject } {
-  const eMap = new BasicEMap<K, V>(owner, feature, entryEClass);
-
-  return new Proxy(eMap, {
-    get(target, prop, receiver) {
-      if (typeof prop === 'string') {
-        const index = parseInt(prop, 10);
-        if (!isNaN(index) && index >= 0) {
-          if (index < target.size()) {
-            return target.get(index);
-          }
-          return undefined;
-        }
-      }
-      return Reflect.get(target, prop, receiver);
-    },
-    set(target, prop, value, receiver) {
-      if (prop === 'length') {
-        const newLength = typeof value === 'number' ? value : parseInt(value, 10);
-        if (newLength === 0) {
-          target.clear();
-          return true;
-        }
-        while (target.size() > newLength) {
-          target.removeAt(target.size() - 1);
-        }
-        return true;
-      }
-      if (typeof prop === 'string') {
-        const index = parseInt(prop, 10);
-        if (!isNaN(index) && index >= 0) {
-          if (index < target.size()) {
-            target.set(index, value);
-            return true;
-          } else if (index === target.size()) {
-            target.add(value);
-            return true;
-          }
-          return false;
-        }
-      }
-      return Reflect.set(target, prop, value, receiver);
-    }
-  }) as unknown as EMap<K, V> & { [index: number]: EObject };
+  return new BasicEMap<K, V>(owner, feature, entryEClass) as EMap<K, V> & { [index: number]: EObject };
 }
 
 /**

--- a/src/EPackage.ts
+++ b/src/EPackage.ts
@@ -102,6 +102,15 @@ export interface EPackageRegistry {
   getEFactory(nsURI: string): EFactory | null;
 
   /**
+   * Registers a package under its own nsURI.
+   *
+   * Equivalent to `set(pkg.getNsURI(), pkg)` and provided because the nsURI is
+   * already part of the package. Throws if the package has no nsURI, since it
+   * could not be looked up afterwards.
+   */
+  registerPackage(ePackage: EPackage): void;
+
+  /**
    * Standard Map operations
    */
   get(nsURI: string): EPackage | EPackageDescriptor | null;
@@ -130,7 +139,7 @@ export namespace EPackageRegistry {
  * automatically registers subpackages to better support dynamically
  * loaded packages (e.g., loading .ecore files at runtime).
  */
-function registerSubpackages(
+export function registerSubpackages(
   map: Map<string, EPackage | EPackageDescriptor>,
   pkg: EPackage
 ): void {
@@ -142,6 +151,20 @@ function registerSubpackages(
     // Recursively register nested subpackages
     registerSubpackages(map, subPkg);
   }
+}
+
+/**
+ * Returns the package's nsURI, or throws if it has none. Registering a package
+ * without an nsURI would silently produce an entry nobody can look up.
+ */
+export function requireNsURI(ePackage: EPackage): string {
+  const nsURI = ePackage.getNsURI();
+  if (!nsURI) {
+    throw new Error(
+      `Cannot register package '${ePackage.getName() ?? '<unnamed>'}': it has no nsURI.`
+    );
+  }
+  return nsURI;
 }
 
 function createGlobalRegistry(): EPackageRegistry {
@@ -176,6 +199,10 @@ function createGlobalRegistry(): EPackageRegistry {
       if (!('getEPackage' in value)) {
         registerSubpackages(map, value as EPackage);
       }
+    },
+
+    registerPackage(ePackage: EPackage) {
+      this.set(requireNsURI(ePackage), ePackage);
     },
 
     delete(nsURI: string) {

--- a/src/ecore/EcorePackage.ts
+++ b/src/ecore/EcorePackage.ts
@@ -25,6 +25,8 @@ import { BasicEEnum } from '../runtime/BasicEEnum.js';
 import { BasicEEnumLiteral } from '../runtime/BasicEEnumLiteral.js';
 import { BasicEOperation } from '../runtime/BasicEOperation.js';
 import { BasicEParameter } from '../runtime/BasicEParameter.js';
+import { BasicEGenericType } from '../runtime/BasicEGenericType.js';
+import { BasicETypeParameter } from '../runtime/BasicETypeParameter.js';
 import { ecoreRegistry } from './EcoreRegistry.js';
 import { getXMLTypePackage } from './XMLTypePackage.js';
 
@@ -606,6 +608,84 @@ export class EcorePackageImpl extends BasicEPackage {
     detailsRef.setContainment(true);
     detailsRef.setUpperBound(-1);
     this._eAnnotationClass.getEStructuralFeatures().push(detailsRef);
+
+    // ===== Generics (#65) =====
+    // Without these features the loader rejects <eGenericType> and
+    // <eTypeParameters> as unknown, and a feature typed generically silently
+    // ends up with no eType at all.
+
+    // ETypedElement.eGenericType
+    const eGenericTypeRef = new BasicEReference();
+    eGenericTypeRef.setName('eGenericType');
+    eGenericTypeRef.setEType(this._eGenericTypeClass);
+    eGenericTypeRef.setContainment(true);
+    this._eTypedElementClass.getEStructuralFeatures().push(eGenericTypeRef);
+
+    // EClassifier.eTypeParameters
+    const eTypeParametersRef = new BasicEReference();
+    eTypeParametersRef.setName('eTypeParameters');
+    eTypeParametersRef.setEType(this._eTypeParameterClass);
+    eTypeParametersRef.setContainment(true);
+    eTypeParametersRef.setUpperBound(-1);
+    this._eClassifierClass.getEStructuralFeatures().push(eTypeParametersRef);
+
+    // EClass.eGenericSuperTypes
+    const eGenericSuperTypesRef = new BasicEReference();
+    eGenericSuperTypesRef.setName('eGenericSuperTypes');
+    eGenericSuperTypesRef.setEType(this._eGenericTypeClass);
+    eGenericSuperTypesRef.setContainment(true);
+    eGenericSuperTypesRef.setUpperBound(-1);
+    this._eClassClass.getEStructuralFeatures().push(eGenericSuperTypesRef);
+
+    // EOperation.eTypeParameters
+    const eOperationTypeParametersRef = new BasicEReference();
+    eOperationTypeParametersRef.setName('eTypeParameters');
+    eOperationTypeParametersRef.setEType(this._eTypeParameterClass);
+    eOperationTypeParametersRef.setContainment(true);
+    eOperationTypeParametersRef.setUpperBound(-1);
+    this._eOperationClass.getEStructuralFeatures().push(eOperationTypeParametersRef);
+
+    // ETypeParameter.eBounds
+    const eBoundsRef = new BasicEReference();
+    eBoundsRef.setName('eBounds');
+    eBoundsRef.setEType(this._eGenericTypeClass);
+    eBoundsRef.setContainment(true);
+    eBoundsRef.setUpperBound(-1);
+    this._eTypeParameterClass.getEStructuralFeatures().push(eBoundsRef);
+
+    // EGenericType.eClassifier - the raw type this generic type refers to
+    const eClassifierRef = new BasicEReference();
+    eClassifierRef.setName('eClassifier');
+    eClassifierRef.setEType(this._eClassifierClass);
+    this._eGenericTypeClass.getEStructuralFeatures().push(eClassifierRef);
+
+    // EGenericType.eTypeParameter
+    const eTypeParameterRef = new BasicEReference();
+    eTypeParameterRef.setName('eTypeParameter');
+    eTypeParameterRef.setEType(this._eTypeParameterClass);
+    this._eGenericTypeClass.getEStructuralFeatures().push(eTypeParameterRef);
+
+    // EGenericType.eTypeArguments
+    const eTypeArgumentsRef = new BasicEReference();
+    eTypeArgumentsRef.setName('eTypeArguments');
+    eTypeArgumentsRef.setEType(this._eGenericTypeClass);
+    eTypeArgumentsRef.setContainment(true);
+    eTypeArgumentsRef.setUpperBound(-1);
+    this._eGenericTypeClass.getEStructuralFeatures().push(eTypeArgumentsRef);
+
+    // EGenericType.eUpperBound
+    const eUpperBoundRef = new BasicEReference();
+    eUpperBoundRef.setName('eUpperBound');
+    eUpperBoundRef.setEType(this._eGenericTypeClass);
+    eUpperBoundRef.setContainment(true);
+    this._eGenericTypeClass.getEStructuralFeatures().push(eUpperBoundRef);
+
+    // EGenericType.eLowerBound
+    const eLowerBoundRef = new BasicEReference();
+    eLowerBoundRef.setName('eLowerBound');
+    eLowerBoundRef.setEType(this._eGenericTypeClass);
+    eLowerBoundRef.setContainment(true);
+    this._eGenericTypeClass.getEStructuralFeatures().push(eLowerBoundRef);
   }
 
   // Getters for EClasses
@@ -625,6 +705,8 @@ export class EcorePackageImpl extends BasicEPackage {
   getEOperationClass(): EClass { return this._eOperationClass; }
   getEParameterClass(): EClass { return this._eParameterClass; }
   getEAnnotationClass(): EClass { return this._eAnnotationClass; }
+  getEGenericTypeClass(): EClass { return this._eGenericTypeClass; }
+  getETypeParameterClass(): EClass { return this._eTypeParameterClass; }
   getEStringToStringMapEntryClass(): EClass { return this._eStringToStringMapEntryClass; }
 
   // Getters for EDataTypes
@@ -682,6 +764,10 @@ export class EcoreFactory extends BasicEFactory {
         return new BasicEOperation();
       case 'EParameter':
         return new BasicEParameter();
+      case 'EGenericType':
+        return new BasicEGenericType();
+      case 'ETypeParameter':
+        return new BasicETypeParameter();
       default:
         return super.create(eClass);
     }

--- a/src/ecore/EcorePackage.ts
+++ b/src/ecore/EcorePackage.ts
@@ -23,6 +23,8 @@ import { BasicEFactory } from '../runtime/BasicEFactory.js';
 import { BasicEAnnotation } from '../runtime/BasicEAnnotation.js';
 import { BasicEEnum } from '../runtime/BasicEEnum.js';
 import { BasicEEnumLiteral } from '../runtime/BasicEEnumLiteral.js';
+import { BasicEOperation } from '../runtime/BasicEOperation.js';
+import { BasicEParameter } from '../runtime/BasicEParameter.js';
 import { ecoreRegistry } from './EcoreRegistry.js';
 import { getXMLTypePackage } from './XMLTypePackage.js';
 
@@ -676,6 +678,10 @@ export class EcoreFactory extends BasicEFactory {
         return new BasicEAnnotation();
       case 'EPackage':
         return new BasicEPackage();
+      case 'EOperation':
+        return new BasicEOperation();
+      case 'EParameter':
+        return new BasicEParameter();
       default:
         return super.create(eClass);
     }

--- a/src/ecore/EcoreRegistry.ts
+++ b/src/ecore/EcoreRegistry.ts
@@ -122,6 +122,26 @@ class EcoreClassRegistry {
   }
 
   /**
+   * Get the EClass for EGenericType
+   */
+  getEGenericTypeClass(): EClass {
+    if (!this._getEcorePackage) {
+      throw new Error('EcorePackage not registered. Import EcorePackage first.');
+    }
+    return this._getEcorePackage().getEGenericTypeClass();
+  }
+
+  /**
+   * Get the EClass for ETypeParameter
+   */
+  getETypeParameterClass(): EClass {
+    if (!this._getEcorePackage) {
+      throw new Error('EcorePackage not registered. Import EcorePackage first.');
+    }
+    return this._getEcorePackage().getETypeParameterClass();
+  }
+
+  /**
    * Get the EClass for EAnnotation
    */
   getEAnnotationClass(): EClass {

--- a/src/ecore/EcoreRegistry.ts
+++ b/src/ecore/EcoreRegistry.ts
@@ -112,6 +112,16 @@ class EcoreClassRegistry {
   }
 
   /**
+   * Get the EClass for EParameter
+   */
+  getEParameterClass(): EClass {
+    if (!this._getEcorePackage) {
+      throw new Error('EcorePackage not registered. Import EcorePackage first.');
+    }
+    return this._getEcorePackage().getEParameterClass();
+  }
+
+  /**
    * Get the EClass for EAnnotation
    */
   getEAnnotationClass(): EClass {

--- a/src/ecore/index.ts
+++ b/src/ecore/index.ts
@@ -49,7 +49,7 @@ export * from './EcoreValidator.js';
 import { BasicResourceSet } from '../runtime/BasicResourceSet.js';
 import { XMIResource, XMIResourceFactory } from '../xmi/XMLResource.js';
 import { URI } from '../URI.js';
-import { EPackage, EPackageRegistry } from '../EPackage.js';
+import { EPackage, EPackageRegistry, requireNsURI, registerSubpackages } from '../EPackage.js';
 import { Resource } from '../Resource.js';
 import { getEcorePackage, ECORE_NS_URI } from './EcorePackage.js';
 
@@ -81,7 +81,10 @@ export class EResourceSetImpl extends BasicResourceSet {
 }
 
 /**
- * Extended package registry with registerPackage method
+ * Creates a standalone package registry.
+ *
+ * registerPackage() is part of EPackageRegistry itself now, so this returns a
+ * plain registry; the intersection type is kept for source compatibility.
  */
 export function createPackageRegistry(): EPackageRegistry & { registerPackage(pkg: EPackage): void } {
   const map = new Map<string, any>();
@@ -105,6 +108,11 @@ export function createPackageRegistry(): EPackageRegistry & { registerPackage(pk
 
     set(nsURI: string, value: any) {
       map.set(nsURI, value);
+      // Register subpackages too, so this registry behaves like every other one
+      // (see the note on registerSubpackages).
+      if (value && !('getEPackage' in value) && typeof value.getESubpackages === 'function') {
+        registerSubpackages(map, value as EPackage);
+      }
     },
 
     delete(nsURI: string) {
@@ -127,10 +135,7 @@ export function createPackageRegistry(): EPackageRegistry & { registerPackage(pk
      * Register a package by its nsURI
      */
     registerPackage(pkg: EPackage) {
-      const nsURI = pkg.getNsURI();
-      if (nsURI) {
-        map.set(nsURI, pkg);
-      }
+      this.set(requireNsURI(pkg), pkg);
     }
   };
 
@@ -138,19 +143,11 @@ export function createPackageRegistry(): EPackageRegistry & { registerPackage(pk
 }
 
 /**
- * Global package registry with registerPackage
+ * Returns the global package registry.
+ *
+ * registerPackage() is part of EPackageRegistry itself now, so the global
+ * instance is returned directly instead of being wrapped.
  */
 export function getPackageRegistry(): EPackageRegistry & { registerPackage(pkg: EPackage): void } {
-  // We extend the global registry
-  const baseRegistry = EPackageRegistry.INSTANCE;
-
-  return {
-    ...baseRegistry,
-    registerPackage(pkg: EPackage) {
-      const nsURI = pkg.getNsURI();
-      if (nsURI) {
-        baseRegistry.set(nsURI, pkg);
-      }
-    }
-  };
+  return EPackageRegistry.INSTANCE;
 }

--- a/src/registry/PackageRegistry.ts
+++ b/src/registry/PackageRegistry.ts
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v20.html
  */
 
-import { EPackage, EPackageRegistry as IEPackageRegistry } from '../EPackage.js';
+import { EPackage, EPackageRegistry as IEPackageRegistry, requireNsURI } from '../EPackage.js';
 import { EFactory } from '../EFactory.js';
 import { Registry, ExtensionListener, Extension } from './PluginRegistry.js';
 import { ExtensionPoints, GeneratedPackageExtension, DynamicPackageExtension } from './ExtensionPoints.js';
@@ -124,6 +124,10 @@ export class ExtensionAwarePackageRegistry implements IEPackageRegistry {
     this.packages.set(nsURI, value);
     // Also register all subpackages recursively
     this.registerSubpackages(value);
+  }
+
+  registerPackage(ePackage: EPackage): void {
+    this.set(requireNsURI(ePackage), ePackage);
   }
 
   /**

--- a/src/runtime/BasicEClass.ts
+++ b/src/runtime/BasicEClass.ts
@@ -16,6 +16,8 @@ import { BasicEObject } from './BasicEObject.js';
 import { EAnnotation } from '../EAnnotation.js';
 import { ecoreRegistry } from '../ecore/EcoreRegistry.js';
 import { EList, EObjectContainmentWithInverseEListLazy, createIndexedProxy } from '../EList.js';
+import { ETypeParameter } from '../ETypeParameter.js';
+import { EGenericType } from '../EGenericType.js';
 import { EObject } from '../EObject.js';
 
 /**
@@ -32,6 +34,8 @@ export class BasicEClass extends BasicEObject implements EClass {
   private instanceClassName: string | null = null;
   private instanceClass: Function | null = null;
   private featureID: number = 0;
+  private eTypeParameters: ETypeParameter[] = [];
+  private eGenericSuperTypes: EGenericType[] = [];
   private eAnnotations: EAnnotation[] = [];
   private xmlNameToFeature: Map<string, EStructuralFeature> = new Map();
 
@@ -272,8 +276,8 @@ export class BasicEClass extends BasicEObject implements EClass {
     this.ePackage = pkg;
   }
 
-  getETypeParameters(): any[] {
-    return [];
+  getETypeParameters(): ETypeParameter[] {
+    return this.eTypeParameters;
   }
 
   isInstance(object: any): boolean {
@@ -355,6 +359,10 @@ export class BasicEClass extends BasicEObject implements EClass {
         return this.getEStructuralFeatures();
       case 'eOperations':
         return this.eOperations;
+      case 'eTypeParameters':
+        return this.eTypeParameters;
+      case 'eGenericSuperTypes':
+        return this.eGenericSuperTypes;
       case 'eAnnotations':
         return this.eAnnotations;
       case 'instanceClassName':
@@ -402,6 +410,18 @@ export class BasicEClass extends BasicEObject implements EClass {
       case 'eOperations':
         if (Array.isArray(newValue)) {
           this.eOperations = newValue;
+        }
+        super.eSet(feature, newValue);
+        break;
+      case 'eTypeParameters':
+        if (Array.isArray(newValue)) {
+          this.eTypeParameters = newValue;
+        }
+        super.eSet(feature, newValue);
+        break;
+      case 'eGenericSuperTypes':
+        if (Array.isArray(newValue)) {
+          this.eGenericSuperTypes = newValue;
         }
         super.eSet(feature, newValue);
         break;

--- a/src/runtime/BasicEDataType.ts
+++ b/src/runtime/BasicEDataType.ts
@@ -11,6 +11,8 @@ import { EPackage } from '../EPackage.js';
 import { EClass } from '../EClass.js';
 import { BasicEObject } from './BasicEObject.js';
 import { EAnnotation } from '../EAnnotation.js';
+import { EStructuralFeature } from '../EStructuralFeature.js';
+import { ETypeParameter } from '../ETypeParameter.js';
 import { ecoreRegistry } from '../ecore/EcoreRegistry.js';
 
 /**
@@ -23,6 +25,7 @@ export class BasicEDataType extends BasicEObject implements EDataType {
   private ePackage: EPackage | null = null;
   private serializable: boolean = true;
   private eAnnotations: EAnnotation[] = [];
+  private eTypeParameters: ETypeParameter[] = [];
 
   getName(): string | null {
     return this.name;
@@ -91,8 +94,8 @@ export class BasicEDataType extends BasicEObject implements EDataType {
     this.ePackage = pkg;
   }
 
-  getETypeParameters(): any[] {
-    return [];
+  getETypeParameters(): ETypeParameter[] {
+    return this.eTypeParameters;
   }
 
   isInstance(object: any): boolean {
@@ -162,6 +165,8 @@ export class BasicEDataType extends BasicEObject implements EDataType {
         return this.serializable;
       case 'eAnnotations':
         return this.eAnnotations;
+      case 'eTypeParameters':
+        return this.eTypeParameters;
       default:
         return super.eGet(feature);
     }
@@ -188,6 +193,12 @@ export class BasicEDataType extends BasicEObject implements EDataType {
       case 'eAnnotations':
         if (Array.isArray(newValue)) {
           this.eAnnotations = newValue;
+        }
+        super.eSet(feature, newValue);
+        break;
+      case 'eTypeParameters':
+        if (Array.isArray(newValue)) {
+          this.eTypeParameters = newValue;
         }
         super.eSet(feature, newValue);
         break;

--- a/src/runtime/BasicEGenericType.ts
+++ b/src/runtime/BasicEGenericType.ts
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2024-2025 Data In Motion Consulting GmbH, Stadt Jena, Software Hochstein GmbH
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+import { EGenericType } from '../EGenericType.js';
+import { ETypeParameter } from '../ETypeParameter.js';
+import { EClass } from '../EClass.js';
+import { EClassifier } from '../EClassifier.js';
+import { EStructuralFeature } from '../EStructuralFeature.js';
+import { BasicEObject } from './BasicEObject.js';
+import { ecoreRegistry } from '../ecore/EcoreRegistry.js';
+
+/**
+ * Basic EGenericType implementation (#65).
+ *
+ * A generic type either refers to a classifier (`Box<EString>` - eClassifier is
+ * Box) or to a type parameter (`T` - eTypeParameter is T). The raw type is the
+ * classifier, which is what a feature's eType resolves to.
+ */
+export class BasicEGenericType extends BasicEObject implements EGenericType {
+  private eClassifier: EClassifier | null = null;
+  private eTypeParameter: ETypeParameter | null = null;
+  private eTypeArguments: EGenericType[] = [];
+  private eUpperBound: EGenericType | null = null;
+  private eLowerBound: EGenericType | null = null;
+
+  getEClassifier(): EClassifier | null {
+    return this.eClassifier;
+  }
+
+  setEClassifier(value: EClassifier | null): void {
+    this.eClassifier = value;
+  }
+
+  getETypeParameter(): ETypeParameter | null {
+    return this.eTypeParameter;
+  }
+
+  setETypeParameter(value: ETypeParameter | null): void {
+    this.eTypeParameter = value;
+  }
+
+  getETypeArguments(): EGenericType[] {
+    return this.eTypeArguments;
+  }
+
+  getEUpperBound(): EGenericType | null {
+    return this.eUpperBound;
+  }
+
+  setEUpperBound(value: EGenericType | null): void {
+    this.eUpperBound = value;
+  }
+
+  getELowerBound(): EGenericType | null {
+    return this.eLowerBound;
+  }
+
+  setELowerBound(value: EGenericType | null): void {
+    this.eLowerBound = value;
+  }
+
+  /**
+   * The erasure of this generic type. For a classifier reference that is the
+   * classifier itself; for a type parameter it is the erasure of its first
+   * bound, mirroring Java EMF's EGenericTypeImpl.getERawType().
+   */
+  getERawType(): EClassifier {
+    if (this.eClassifier) {
+      return this.eClassifier;
+    }
+    if (this.eTypeParameter) {
+      const bounds = this.eTypeParameter.getEBounds();
+      if (bounds.length > 0) {
+        return bounds[0].getERawType();
+      }
+    }
+    if (this.eUpperBound) {
+      return this.eUpperBound.getERawType();
+    }
+    return ecoreRegistry.getEObjectClass();
+  }
+
+  override eClass(): EClass {
+    return ecoreRegistry.getEGenericTypeClass();
+  }
+
+  override eGet(feature: EStructuralFeature): any {
+    switch (feature.getName()) {
+      case 'eClassifier':
+        return this.eClassifier;
+      case 'eTypeParameter':
+        return this.eTypeParameter;
+      case 'eTypeArguments':
+        return this.eTypeArguments;
+      case 'eUpperBound':
+        return this.eUpperBound;
+      case 'eLowerBound':
+        return this.eLowerBound;
+      default:
+        return super.eGet(feature);
+    }
+  }
+
+  override eSet(feature: EStructuralFeature, newValue: any): void {
+    switch (feature.getName()) {
+      case 'eClassifier':
+        this.eClassifier = newValue;
+        break;
+      case 'eTypeParameter':
+        this.eTypeParameter = newValue;
+        break;
+      case 'eTypeArguments':
+        if (Array.isArray(newValue)) {
+          this.eTypeArguments = newValue;
+        }
+        break;
+      case 'eUpperBound':
+        this.eUpperBound = newValue;
+        break;
+      case 'eLowerBound':
+        this.eLowerBound = newValue;
+        break;
+    }
+    super.eSet(feature, newValue);
+  }
+}

--- a/src/runtime/BasicEOperation.ts
+++ b/src/runtime/BasicEOperation.ts
@@ -11,6 +11,8 @@ import { EClass } from '../EClass.js';
 import { EClassifier } from '../EClassifier.js';
 import { EParameter } from '../EParameter.js';
 import { EStructuralFeature } from '../EStructuralFeature.js';
+import { EGenericType } from '../EGenericType.js';
+import { ETypeParameter } from '../ETypeParameter.js';
 import { BasicEObject } from './BasicEObject.js';
 import { EAnnotation } from '../EAnnotation.js';
 import { ecoreRegistry } from '../ecore/EcoreRegistry.js';
@@ -25,6 +27,8 @@ export class BasicEOperation extends BasicEObject implements EOperation {
   private eParameters: EParameter[] = [];
   private eExceptions: EClassifier[] = [];
   private eAnnotations: EAnnotation[] = [];
+  private eGenericType: EGenericType | null = null;
+  private eTypeParameters: ETypeParameter[] = [];
   private ordered: boolean = true;
   private unique: boolean = true;
   private lowerBound: number = 0;
@@ -47,7 +51,23 @@ export class BasicEOperation extends BasicEObject implements EOperation {
   }
 
   getEType(): EClassifier | null {
+    // A generically typed operation carries no eType attribute (#65).
+    if (!this.eType && this.eGenericType) {
+      return this.eGenericType.getERawType();
+    }
     return this.eType;
+  }
+
+  getEGenericType(): EGenericType | null {
+    return this.eGenericType;
+  }
+
+  setEGenericType(value: EGenericType | null): void {
+    this.eGenericType = value;
+  }
+
+  getETypeParameters(): ETypeParameter[] {
+    return this.eTypeParameters;
   }
 
   setEType(value: EClassifier | null): void {
@@ -167,6 +187,10 @@ export class BasicEOperation extends BasicEObject implements EOperation {
         return this.name;
       case 'eType':
         return this.eType;
+      case 'eGenericType':
+        return this.eGenericType;
+      case 'eTypeParameters':
+        return this.eTypeParameters;
       case 'eParameters':
         return this.eParameters;
       case 'eExceptions':
@@ -193,6 +217,14 @@ export class BasicEOperation extends BasicEObject implements EOperation {
         break;
       case 'eType':
         this.eType = newValue;
+        break;
+      case 'eGenericType':
+        this.eGenericType = newValue;
+        break;
+      case 'eTypeParameters':
+        if (Array.isArray(newValue)) {
+          this.eTypeParameters = newValue;
+        }
         break;
       case 'eParameters':
         if (Array.isArray(newValue)) {

--- a/src/runtime/BasicEParameter.ts
+++ b/src/runtime/BasicEParameter.ts
@@ -11,6 +11,7 @@ import { EClass } from '../EClass.js';
 import { EClassifier } from '../EClassifier.js';
 import { EOperation } from '../EOperation.js';
 import { EStructuralFeature } from '../EStructuralFeature.js';
+import { EGenericType } from '../EGenericType.js';
 import { BasicEObject } from './BasicEObject.js';
 import { EAnnotation } from '../EAnnotation.js';
 import { ecoreRegistry } from '../ecore/EcoreRegistry.js';
@@ -26,6 +27,7 @@ export class BasicEParameter extends BasicEObject implements EParameter {
   private eType: EClassifier | null = null;
   private eOperation: EOperation | null = null;
   private eAnnotations: EAnnotation[] = [];
+  private eGenericType: EGenericType | null = null;
   private ordered: boolean = true;
   private unique: boolean = true;
   private lowerBound: number = 0;
@@ -40,7 +42,19 @@ export class BasicEParameter extends BasicEObject implements EParameter {
   }
 
   getEType(): EClassifier | null {
+    // A generically typed parameter carries no eType attribute (#65).
+    if (!this.eType && this.eGenericType) {
+      return this.eGenericType.getERawType();
+    }
     return this.eType;
+  }
+
+  getEGenericType(): EGenericType | null {
+    return this.eGenericType;
+  }
+
+  setEGenericType(value: EGenericType | null): void {
+    this.eGenericType = value;
   }
 
   setEType(value: EClassifier | null): void {
@@ -117,6 +131,8 @@ export class BasicEParameter extends BasicEObject implements EParameter {
         return this.name;
       case 'eType':
         return this.eType;
+      case 'eGenericType':
+        return this.eGenericType;
       case 'eAnnotations':
         return this.eAnnotations;
       case 'ordered':
@@ -139,6 +155,9 @@ export class BasicEParameter extends BasicEObject implements EParameter {
         break;
       case 'eType':
         this.eType = newValue;
+        break;
+      case 'eGenericType':
+        this.eGenericType = newValue;
         break;
       case 'eAnnotations':
         if (Array.isArray(newValue)) {

--- a/src/runtime/BasicEParameter.ts
+++ b/src/runtime/BasicEParameter.ts
@@ -6,24 +6,25 @@
  * http://www.eclipse.org/legal/epl-v20.html
  */
 
-import { EOperation } from '../EOperation.js';
+import { EParameter } from '../EParameter.js';
 import { EClass } from '../EClass.js';
 import { EClassifier } from '../EClassifier.js';
-import { EParameter } from '../EParameter.js';
+import { EOperation } from '../EOperation.js';
 import { EStructuralFeature } from '../EStructuralFeature.js';
 import { BasicEObject } from './BasicEObject.js';
 import { EAnnotation } from '../EAnnotation.js';
 import { ecoreRegistry } from '../ecore/EcoreRegistry.js';
 
 /**
- * Basic EOperation implementation
+ * Basic EParameter implementation.
+ *
+ * Used by EcoreFactory when loading .ecore files, so nested parameters arrive as
+ * typed objects rather than DynamicEObject (#66).
  */
-export class BasicEOperation extends BasicEObject implements EOperation {
+export class BasicEParameter extends BasicEObject implements EParameter {
   private name: string | null = null;
-  private eContainingClass: EClass | null = null;
   private eType: EClassifier | null = null;
-  private eParameters: EParameter[] = [];
-  private eExceptions: EClassifier[] = [];
+  private eOperation: EOperation | null = null;
   private eAnnotations: EAnnotation[] = [];
   private ordered: boolean = true;
   private unique: boolean = true;
@@ -38,14 +39,6 @@ export class BasicEOperation extends BasicEObject implements EOperation {
     this.name = value;
   }
 
-  getEContainingClass(): EClass | null {
-    return this.eContainingClass;
-  }
-
-  setEContainingClass(value: EClass | null): void {
-    this.eContainingClass = value;
-  }
-
   getEType(): EClassifier | null {
     return this.eType;
   }
@@ -54,20 +47,28 @@ export class BasicEOperation extends BasicEObject implements EOperation {
     this.eType = value;
   }
 
-  getEParameters(): EParameter[] {
-    return this.eParameters;
+  getEOperation(): EOperation | null {
+    return this.eOperation;
   }
 
-  addParameter(parameter: EParameter): void {
-    this.eParameters.push(parameter);
+  setEOperation(value: EOperation | null): void {
+    this.eOperation = value;
   }
 
-  getEExceptions(): EClassifier[] {
-    return this.eExceptions;
+  isOrdered(): boolean {
+    return this.ordered;
   }
 
-  addException(exception: EClassifier): void {
-    this.eExceptions.push(exception);
+  setOrdered(value: boolean): void {
+    this.ordered = value;
+  }
+
+  isUnique(): boolean {
+    return this.unique;
+  }
+
+  setUnique(value: boolean): void {
+    this.unique = value;
   }
 
   isMany(): boolean {
@@ -94,57 +95,6 @@ export class BasicEOperation extends BasicEObject implements EOperation {
     this.upperBound = value;
   }
 
-  getOperationID(): number {
-    if (!this.eContainingClass) return -1;
-    return this.eContainingClass.getOperationID(this);
-  }
-
-  isOverrideOf(someOperation: EOperation): boolean {
-    if (this.name !== someOperation.getName()) {
-      return false;
-    }
-
-    // Check parameter count
-    const myParams = this.eParameters;
-    const otherParams = someOperation.getEParameters();
-    if (myParams.length !== otherParams.length) {
-      return false;
-    }
-
-    // Check parameter types
-    for (let i = 0; i < myParams.length; i++) {
-      const myParamType = myParams[i].getEType();
-      const otherParamType = otherParams[i].getEType();
-      if (myParamType !== otherParamType) {
-        return false;
-      }
-    }
-
-    // Check if containing class is subtype
-    if (!this.eContainingClass || !someOperation.getEContainingClass()) {
-      return false;
-    }
-
-    return this.eContainingClass.getEAllSuperTypes().includes(someOperation.getEContainingClass()!);
-  }
-
-  isOrdered(): boolean {
-    return this.ordered;
-  }
-
-  setOrdered(value: boolean): void {
-    this.ordered = value;
-  }
-
-  isUnique(): boolean {
-    return this.unique;
-  }
-
-  setUnique(value: boolean): void {
-    this.unique = value;
-  }
-
-  // EObject methods
   getEAnnotations(): EAnnotation[] {
     return this.eAnnotations;
   }
@@ -154,7 +104,7 @@ export class BasicEOperation extends BasicEObject implements EOperation {
   }
 
   override eClass(): EClass {
-    return ecoreRegistry.getEOperationClass();
+    return ecoreRegistry.getEParameterClass();
   }
 
   /**
@@ -167,10 +117,6 @@ export class BasicEOperation extends BasicEObject implements EOperation {
         return this.name;
       case 'eType':
         return this.eType;
-      case 'eParameters':
-        return this.eParameters;
-      case 'eExceptions':
-        return this.eExceptions;
       case 'eAnnotations':
         return this.eAnnotations;
       case 'ordered':
@@ -194,16 +140,6 @@ export class BasicEOperation extends BasicEObject implements EOperation {
       case 'eType':
         this.eType = newValue;
         break;
-      case 'eParameters':
-        if (Array.isArray(newValue)) {
-          this.eParameters = newValue;
-        }
-        break;
-      case 'eExceptions':
-        if (Array.isArray(newValue)) {
-          this.eExceptions = newValue;
-        }
-        break;
       case 'eAnnotations':
         if (Array.isArray(newValue)) {
           this.eAnnotations = newValue;
@@ -223,44 +159,5 @@ export class BasicEOperation extends BasicEObject implements EOperation {
         break;
     }
     super.eSet(feature, newValue);
-  }
-}
-
-/**
- * Builder for creating EOperation instances
- */
-export class EOperationBuilder {
-  private op: BasicEOperation;
-
-  constructor(name: string, returnType?: EClassifier) {
-    this.op = new BasicEOperation();
-    this.op.setName(name);
-    if (returnType) {
-      this.op.setEType(returnType);
-    }
-  }
-
-  parameter(param: EParameter): this {
-    this.op.addParameter(param);
-    return this;
-  }
-
-  exception(exception: EClassifier): this {
-    this.op.addException(exception);
-    return this;
-  }
-
-  required(value: boolean = true): this {
-    this.op.setLowerBound(value ? 1 : 0);
-    return this;
-  }
-
-  many(value: boolean = true): this {
-    this.op.setUpperBound(value ? -1 : 1);
-    return this;
-  }
-
-  build(): EOperation {
-    return this.op;
   }
 }

--- a/src/runtime/BasicEStructuralFeature.ts
+++ b/src/runtime/BasicEStructuralFeature.ts
@@ -8,6 +8,7 @@
 
 import { EStructuralFeature } from '../EStructuralFeature.js';
 import { EClassifier } from '../EClassifier.js';
+import { EGenericType } from '../EGenericType.js';
 import { EClass } from '../EClass.js';
 import { BasicEObject } from './BasicEObject.js';
 import { EAnnotation } from '../EAnnotation.js';
@@ -28,6 +29,7 @@ export abstract class BasicEStructuralFeature extends BasicEObject implements ES
   private unsettable: boolean = false;
   private derived: boolean = false;
   private eType: EClassifier | null = null;
+  private eGenericType: EGenericType | null = null;
   private eContainingClass: EClass | null = null;
   private lowerBound: number = 0;
   private upperBound: number = 1;
@@ -166,11 +168,24 @@ export abstract class BasicEStructuralFeature extends BasicEObject implements ES
         }
       }
     }
+    // A feature typed via <eGenericType> carries no eType attribute; the type
+    // is the raw type of the generic type (#65).
+    if (!this.eType && this.eGenericType) {
+      return this.eGenericType.getERawType();
+    }
     return this.eType;
   }
 
   setEType(value: EClassifier | null): void {
     this.eType = value;
+  }
+
+  getEGenericType(): EGenericType | null {
+    return this.eGenericType;
+  }
+
+  setEGenericType(value: EGenericType | null): void {
+    this.eGenericType = value;
   }
 
   getEContainingClass(): EClass | null {
@@ -248,6 +263,8 @@ export abstract class BasicEStructuralFeature extends BasicEObject implements ES
         return this.derived;
       case 'eType':
         return this.eType;
+      case 'eGenericType':
+        return this.eGenericType;
       case 'lowerBound':
         return this.lowerBound;
       case 'upperBound':
@@ -295,6 +312,10 @@ export abstract class BasicEStructuralFeature extends BasicEObject implements ES
         break;
       case 'eType':
         this.eType = newValue;
+        super.eSet(feature, newValue);
+        break;
+      case 'eGenericType':
+        this.eGenericType = newValue;
         super.eSet(feature, newValue);
         break;
       case 'lowerBound':

--- a/src/runtime/BasicETypeParameter.ts
+++ b/src/runtime/BasicETypeParameter.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2024-2025 Data In Motion Consulting GmbH, Stadt Jena, Software Hochstein GmbH
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+import { ETypeParameter } from '../ETypeParameter.js';
+import { EGenericType } from '../EGenericType.js';
+import { EClass } from '../EClass.js';
+import { EStructuralFeature } from '../EStructuralFeature.js';
+import { BasicEObject } from './BasicEObject.js';
+import { EAnnotation } from '../EAnnotation.js';
+import { ecoreRegistry } from '../ecore/EcoreRegistry.js';
+
+/**
+ * Basic ETypeParameter implementation (#65).
+ *
+ * Declares a type variable such as the `T` in `class Box<T>`.
+ */
+export class BasicETypeParameter extends BasicEObject implements ETypeParameter {
+  private name: string | null = null;
+  private eBounds: EGenericType[] = [];
+  private eAnnotations: EAnnotation[] = [];
+
+  getName(): string | null {
+    return this.name;
+  }
+
+  setName(value: string | null): void {
+    this.name = value;
+  }
+
+  getEBounds(): EGenericType[] {
+    return this.eBounds;
+  }
+
+  getEAnnotations(): EAnnotation[] {
+    return this.eAnnotations;
+  }
+
+  getEAnnotation(source: string): EAnnotation | null {
+    return this.eAnnotations.find(a => a.getSource() === source) || null;
+  }
+
+  override eClass(): EClass {
+    return ecoreRegistry.getETypeParameterClass();
+  }
+
+  override eGet(feature: EStructuralFeature): any {
+    switch (feature.getName()) {
+      case 'name':
+        return this.name;
+      case 'eBounds':
+        return this.eBounds;
+      case 'eAnnotations':
+        return this.eAnnotations;
+      default:
+        return super.eGet(feature);
+    }
+  }
+
+  override eSet(feature: EStructuralFeature, newValue: any): void {
+    switch (feature.getName()) {
+      case 'name':
+        this.name = newValue;
+        break;
+      case 'eBounds':
+        if (Array.isArray(newValue)) {
+          this.eBounds = newValue;
+        }
+        break;
+      case 'eAnnotations':
+        if (Array.isArray(newValue)) {
+          this.eAnnotations = newValue;
+        }
+        break;
+    }
+    super.eSet(feature, newValue);
+  }
+}

--- a/src/runtime/BasicResourceSet.ts
+++ b/src/runtime/BasicResourceSet.ts
@@ -10,7 +10,7 @@ import { ResourceSet, URIConverter } from '../ResourceSet.js';
 import { Resource } from '../Resource.js';
 import { URI } from '../URI.js';
 import { EObject } from '../EObject.js';
-import { EPackage, EPackageRegistry } from '../EPackage.js';
+import { EPackage, EPackageRegistry, requireNsURI } from '../EPackage.js';
 import { BasicResource } from './BasicResource.js';
 import { EList, BasicEList, createIndexedProxy } from '../EList.js';
 import { EClass } from '../EClass.js';
@@ -355,6 +355,10 @@ export class BasicResourceSet implements ResourceSet {
         if (value && !('getEPackage' in value) && typeof value.getESubpackages === 'function') {
           registerSubpackages(value as EPackage);
         }
+      },
+
+      registerPackage(ePackage: EPackage) {
+        this.set(requireNsURI(ePackage), ePackage);
       },
 
       delete(nsURI: string) {

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -21,5 +21,7 @@ export * from './BasicEEnumLiteral.js';
 export * from './BasicEAnnotation.js';
 export * from './BasicEOperation.js';
 export * from './BasicEParameter.js';
+export * from './BasicEGenericType.js';
+export * from './BasicETypeParameter.js';
 export * from './DataTypeRegistry.js';
 export * from './EProxyImpl.js';

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -20,5 +20,6 @@ export * from './BasicEEnum.js';
 export * from './BasicEEnumLiteral.js';
 export * from './BasicEAnnotation.js';
 export * from './BasicEOperation.js';
+export * from './BasicEParameter.js';
 export * from './DataTypeRegistry.js';
 export * from './EProxyImpl.js';

--- a/tests/EList.test.ts
+++ b/tests/EList.test.ts
@@ -36,6 +36,8 @@ import {
   EcoreDataTypes,
   EList,
   isEList,
+  BasicEList,
+  createIndexedProxy,
 } from '../src';
 
 /**
@@ -736,6 +738,192 @@ describe('EList', () => {
       children.set(0, child);
 
       expect(adapter.notifications).toHaveLength(0);
+    });
+  });
+
+  /**
+   * Array compatibility (#68).
+   *
+   * An EList is indexable and iterable but deliberately not an Array - see the
+   * contract documented on the EList interface. These tests pin both halves:
+   * what an EList does provide, and the one thing it must keep refusing.
+   */
+  describe('Array compatibility (#68)', () => {
+    it('should support index reads on a directly constructed list', () => {
+      const list = new BasicEList<string>();
+      list.add('a');
+      list.add('b');
+
+      expect(list[0]).toBe('a');
+      expect(list[1]).toBe('b');
+      expect(list[2]).toBeUndefined();
+    });
+
+    it('should route index writes through set() so notifications are sent', () => {
+      const parent = factory.create(PersonClass);
+      const child1 = factory.create(PersonClass);
+      const child2 = factory.create(PersonClass);
+      const children = parent.eGet(childrenRef) as EList<EObject>;
+      children.add(child1);
+
+      const adapter = new RecordingAdapter();
+      (parent as any).eAdapterAdd(adapter);
+
+      children[0] = child2;
+
+      expect(children.get(0)).toBe(child2);
+      expect(adapter.notifications).toHaveLength(1);
+      expect(adapter.notifications[0].getEventType()).toBe(NotificationType.SET);
+    });
+
+    it('should append when assigning at list[length]', () => {
+      const parent = factory.create(PersonClass);
+      const child = factory.create(PersonClass);
+      const children = parent.eGet(childrenRef) as EList<EObject>;
+
+      const adapter = new RecordingAdapter();
+      (parent as any).eAdapterAdd(adapter);
+
+      children[0] = child;
+
+      expect(children.size()).toBe(1);
+      expect(adapter.notifications[0].getEventType()).toBe(NotificationType.ADD);
+    });
+
+    it('should reject sparse assignment beyond the end', () => {
+      const list = new BasicEList<string>();
+      list.add('a');
+
+      expect(() => {
+        list[5] = 'x';
+      }).toThrow(RangeError);
+    });
+
+    it('should clear the list when length is set to 0', () => {
+      const parent = factory.create(PersonClass);
+      const children = parent.eGet(childrenRef) as EList<EObject>;
+      children.add(factory.create(PersonClass));
+      children.add(factory.create(PersonClass));
+
+      const adapter = new RecordingAdapter();
+      (parent as any).eAdapterAdd(adapter);
+
+      (children as any).length = 0;
+
+      expect(children.size()).toBe(0);
+      expect(adapter.notifications.length).toBeGreaterThan(0);
+    });
+
+    it('should truncate the tail when length is reduced', () => {
+      const list = new BasicEList<string>();
+      list.addAll(['a', 'b', 'c']);
+
+      (list as any).length = 1;
+
+      expect(list.toArray()).toEqual(['a']);
+    });
+
+    it('should report the index via the in operator', () => {
+      const list = new BasicEList<string>();
+      list.add('a');
+
+      expect(0 in list).toBe(true);
+      expect(1 in list).toBe(false);
+    });
+
+    it('should serialize as a plain array', () => {
+      const list = new BasicEList<string>();
+      list.addAll(['a', 'b']);
+
+      expect(JSON.stringify(list)).toBe('["a","b"]');
+    });
+
+    it('should not serialize the internal owner and feature fields', () => {
+      // Without toJSON() this produced {"data":[...],"owner":...,"feature":...}
+      // and dragged the owning EObject into the output. Note that a list of
+      // EObjects can still not be stringified - EObjects are cyclic themselves
+      // via _eContainer, which is outside the scope of this list contract.
+      const person = factory.create(PersonClass);
+      const list = new BasicEList<string>(person, nameAttr);
+      list.addAll(['a', 'b']);
+
+      expect(JSON.stringify(list)).toBe('["a","b"]');
+      expect(list.toJSON()).toEqual(['a', 'b']);
+      expect(Array.isArray(list.toJSON())).toBe(true);
+    });
+
+    it('should concat values, arrays and other ELists', () => {
+      const list = new BasicEList<string>();
+      list.add('a');
+      const other = new BasicEList<string>();
+      other.add('d');
+
+      expect(list.concat('b', ['c'], other)).toEqual(['a', 'b', 'c', 'd']);
+      expect(list.toArray()).toEqual(['a']);
+    });
+
+    it('should sort in place and emit MOVE notifications', () => {
+      const parent = factory.create(PersonClass);
+      const children = parent.eGet(childrenRef) as EList<EObject>;
+      const c1 = factory.create(PersonClass);
+      const c2 = factory.create(PersonClass);
+      c1.eSet(nameAttr, 'B');
+      c2.eSet(nameAttr, 'A');
+      children.addAll([c1, c2]);
+
+      const adapter = new RecordingAdapter();
+      (parent as any).eAdapterAdd(adapter);
+
+      const result = children.sort((a, b) =>
+        String(a.eGet(nameAttr)).localeCompare(String(b.eGet(nameAttr)))
+      );
+
+      expect(result).toBe(children);
+      expect(children.get(0)).toBe(c2);
+      expect(adapter.notifications.some(n => n.getEventType() === NotificationType.MOVE)).toBe(true);
+    });
+
+    it('should reverse in place', () => {
+      const list = new BasicEList<string>();
+      list.addAll(['a', 'b', 'c']);
+
+      expect(list.reverse().toArray()).toEqual(['c', 'b', 'a']);
+    });
+
+    it('should provide join, at and lastIndexOf', () => {
+      const list = new BasicEList<string>();
+      list.addAll(['a', 'b', 'a']);
+
+      expect(list.join('-')).toBe('a-b-a');
+      expect(list.at(0)).toBe('a');
+      expect(list.at(-1)).toBe('a');
+      expect(list.at(3)).toBeUndefined();
+      expect(list.lastIndexOf('a')).toBe(2);
+    });
+
+    it('should provide flatMap', () => {
+      const list = new BasicEList<string>();
+      list.addAll(['a', 'b']);
+
+      expect(list.flatMap(v => [v, v.toUpperCase()])).toEqual(['a', 'A', 'b', 'B']);
+    });
+
+    it('should NOT be an Array', () => {
+      // Deliberate: inheriting from Array would expose the length setter and raw
+      // index assignment, both of which bypass notifications. Array.from() is
+      // the documented way to obtain a real array.
+      const list = new BasicEList<string>();
+      list.add('a');
+
+      expect(Array.isArray(list)).toBe(false);
+      expect(Array.from(list)).toEqual(['a']);
+      expect([...list]).toEqual(['a']);
+    });
+
+    it('should not stack a second proxy in createIndexedProxy', () => {
+      const list = new BasicEList<string>();
+
+      expect(createIndexedProxy(list)).toBe(list);
     });
   });
 });

--- a/tests/EcoreMetamodelLoad.test.ts
+++ b/tests/EcoreMetamodelLoad.test.ts
@@ -11,7 +11,7 @@
 import { describe, it, expect } from 'vitest';
 import { EResourceSetImpl } from '../src/ecore/index.js';
 import { URI } from '../src/URI.js';
-import { BasicEOperation, BasicEParameter } from '../src/runtime/index.js';
+import { BasicEOperation, BasicEParameter, BasicEGenericType } from '../src/runtime/index.js';
 import type { EPackage } from '../src/EPackage.js';
 import type { EClass } from '../src/EClass.js';
 import type { Resource } from '../src/Resource.js';
@@ -143,5 +143,29 @@ describe('eGenericType provides the feature type (#65)', () => {
     expect(box.getName()).toBe('Box');
     expect(box.getETypeParameters()).toHaveLength(1);
     expect(box.getETypeParameters()[0].getName()).toBe('T');
+  });
+
+  it('should keep the generic type structure including its type arguments', () => {
+    // The issue would have accepted dropping the type arguments; they survive.
+    const holder = firstClass(load(GENERICS_MODEL, 'generics.ecore'));
+    const label = holder.getEStructuralFeatures().get(0) as any;
+    const genericType = label.getEGenericType();
+
+    expect(genericType).toBeInstanceOf(BasicEGenericType);
+    expect(genericType.getEClassifier()?.getName()).toBe('Box');
+    expect(genericType.getETypeArguments()).toHaveLength(1);
+    expect(genericType.getETypeArguments()[0].getEClassifier()?.getName()).toBe('EString');
+  });
+
+  it('should serialize eGenericType back out and survive a round trip', () => {
+    const saved = (load(GENERICS_MODEL, 'generics.ecore') as any).saveToString();
+
+    expect(saved).toContain('<eGenericType eClassifier="#//Box">');
+    expect(saved).toContain('<eTypeArguments');
+    expect(saved).toContain('<eTypeParameters name="T"/>');
+
+    // Reloading the serialized form yields the same type again.
+    const reloaded = firstClass(load(saved, 'generics-2.ecore'));
+    expect(reloaded.getEStructuralFeatures().get(0).getEType()?.getName()).toBe('Box');
   });
 });

--- a/tests/EcoreMetamodelLoad.test.ts
+++ b/tests/EcoreMetamodelLoad.test.ts
@@ -1,0 +1,147 @@
+/**
+ * @fileoverview Tests for loading nested Ecore metamodel elements (#65, #66)
+ *
+ * Covers the two reported gaps when reading an .ecore file:
+ * - #66: EOperation and EParameter must arrive as typed Basic* objects, not as
+ *   DynamicEObject, so that the accessors declared on the interfaces work.
+ * - #65: a feature typed via <eGenericType> must end up with an eType.
+ *
+ * @module tests/EcoreMetamodelLoad
+ */
+import { describe, it, expect } from 'vitest';
+import { EResourceSetImpl } from '../src/ecore/index.js';
+import { URI } from '../src/URI.js';
+import { BasicEOperation, BasicEParameter } from '../src/runtime/index.js';
+import type { EPackage } from '../src/EPackage.js';
+import type { EClass } from '../src/EClass.js';
+import type { Resource } from '../src/Resource.js';
+
+const ECORE_STRING = 'ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString';
+const ECORE_INT = 'ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt';
+
+const OPERATIONS_MODEL = `<?xml version="1.0" encoding="UTF-8"?>
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore"
+    name="t" nsURI="http://test/ops" nsPrefix="t">
+  <eClassifiers xsi:type="ecore:EClass" name="Svc">
+    <eOperations name="doIt" eType="${ECORE_STRING}">
+      <eAnnotations source="http://example.org/doc">
+        <details key="documentation" value="does it"/>
+      </eAnnotations>
+      <eParameters name="arg" eType="${ECORE_INT}"/>
+      <eParameters name="flag" eType="${ECORE_STRING}" upperBound="-1"/>
+    </eOperations>
+  </eClassifiers>
+</ecore:EPackage>`;
+
+const GENERICS_MODEL = `<?xml version="1.0" encoding="UTF-8"?>
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore"
+    name="t" nsURI="http://test/generics" nsPrefix="t">
+  <eClassifiers xsi:type="ecore:EClass" name="Holder">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="label" containment="false">
+      <eGenericType eClassifier="http://test/generics#//Box">
+        <eTypeArguments eClassifier="${ECORE_STRING}"/>
+      </eGenericType>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="plain" eType="${ECORE_STRING}"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Box">
+    <eTypeParameters name="T"/>
+  </eClassifiers>
+</ecore:EPackage>`;
+
+function load(model: string, fileName: string): Resource {
+  const resourceSet = new EResourceSetImpl();
+  const resource = resourceSet.createResource(URI.createURI(fileName));
+  (resource as any).loadFromString(model);
+  return resource;
+}
+
+function firstClass(resource: Resource): EClass {
+  const pkg = resource.getContents().get(0) as EPackage;
+  return pkg.getEClassifiers().get(0) as EClass;
+}
+
+describe('Nested model elements are typed (#66)', () => {
+  it('should load EOperation as BasicEOperation', () => {
+    const svc = firstClass(load(OPERATIONS_MODEL, 'ops.ecore'));
+    const operations = svc.getEOperations();
+
+    expect(operations).toHaveLength(1);
+    expect(operations[0]).toBeInstanceOf(BasicEOperation);
+  });
+
+  it('should expose the typed accessors on a loaded EOperation', () => {
+    const svc = firstClass(load(OPERATIONS_MODEL, 'ops.ecore'));
+    const operation = svc.getEOperations()[0];
+
+    expect(operation.getName()).toBe('doIt');
+    expect(operation.getEType()?.getName()).toBe('EString');
+    expect(typeof operation.getEAnnotation).toBe('function');
+  });
+
+  it('should load EParameter as BasicEParameter with its attributes', () => {
+    const svc = firstClass(load(OPERATIONS_MODEL, 'ops.ecore'));
+    const parameters = svc.getEOperations()[0].getEParameters();
+
+    expect(parameters).toHaveLength(2);
+    expect(parameters[0]).toBeInstanceOf(BasicEParameter);
+    expect(parameters[0].getName()).toBe('arg');
+    expect(parameters[0].getEType()?.getName()).toBe('EInt');
+    expect(parameters[1].getUpperBound()).toBe(-1);
+    expect(parameters[1].isMany()).toBe(true);
+  });
+
+  it('should find an annotation on a loaded EOperation', () => {
+    // getEAnnotations() used to be a stub returning [], so even a typed
+    // EOperation could not resolve its annotations.
+    const svc = firstClass(load(OPERATIONS_MODEL, 'ops.ecore'));
+    const operation = svc.getEOperations()[0];
+
+    expect(operation.getEAnnotations()).toHaveLength(1);
+    expect(operation.getEAnnotation('http://example.org/doc')).not.toBeNull();
+    expect(operation.getEAnnotation('http://example.org/missing')).toBeNull();
+  });
+
+  it('should load without errors', () => {
+    const resource = load(OPERATIONS_MODEL, 'ops.ecore');
+
+    expect(resource.getErrors()).toHaveLength(0);
+  });
+});
+
+describe('eGenericType provides the feature type (#65)', () => {
+  it('should load without errors', () => {
+    const resource = load(GENERICS_MODEL, 'generics.ecore');
+
+    expect(resource.getErrors().map(e => String((e as any).message ?? e))).toEqual([]);
+  });
+
+  it('should give a feature typed via eGenericType its base type', () => {
+    const holder = firstClass(load(GENERICS_MODEL, 'generics.ecore'));
+    const label = holder.getEStructuralFeatures().get(0);
+
+    expect(label.getName()).toBe('label');
+    expect(label.getEType()?.getName()).toBe('Box');
+  });
+
+  it('should keep resolving plain eType attributes', () => {
+    const holder = firstClass(load(GENERICS_MODEL, 'generics.ecore'));
+    const plain = holder.getEStructuralFeatures().get(1);
+
+    expect(plain.getEType()?.getName()).toBe('EString');
+  });
+
+  it('should record the type parameters of a class', () => {
+    const resource = load(GENERICS_MODEL, 'generics.ecore');
+    const pkg = resource.getContents().get(0) as EPackage;
+    const box = pkg.getEClassifiers().get(1) as EClass;
+
+    expect(box.getName()).toBe('Box');
+    expect(box.getETypeParameters()).toHaveLength(1);
+    expect(box.getETypeParameters()[0].getName()).toBe('T');
+  });
+});

--- a/tests/PackageRegistry.test.ts
+++ b/tests/PackageRegistry.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @fileoverview Tests for EPackageRegistry.registerPackage (#67)
+ *
+ * registerPackage(pkg) is part of the EPackageRegistry interface, so every way
+ * of obtaining a registry behaves the same. Previously only the registries from
+ * src/ecore/index.ts had the method, while the registry of a ResourceSet did
+ * not - which is what #67 reported.
+ *
+ * @module tests/PackageRegistry
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  BasicEPackage,
+  EPackage,
+  EPackageRegistry,
+  EResourceSetImpl,
+  createPackageRegistry,
+  getPackageRegistry,
+} from '../src';
+import { ExtensionAwarePackageRegistry } from '../src/registry/PackageRegistry.js';
+
+/** nsURIs touched by these tests, removed from the global registry afterwards. */
+const NS_MAIN = 'http://test.registry/main';
+const NS_SUB = 'http://test.registry/sub';
+
+function createPackageWithSubpackage(): EPackage {
+  const pkg = new BasicEPackage();
+  pkg.setName('main');
+  pkg.setNsURI(NS_MAIN);
+  pkg.setNsPrefix('main');
+
+  const sub = new BasicEPackage();
+  sub.setName('sub');
+  sub.setNsURI(NS_SUB);
+  sub.setNsPrefix('sub');
+  pkg.getESubpackages().add(sub);
+
+  return pkg;
+}
+
+/**
+ * The four ways to obtain a registry. All of them must accept registerPackage.
+ */
+const registries: [string, () => EPackageRegistry][] = [
+  ['ResourceSet registry', () => new EResourceSetImpl().getPackageRegistry()],
+  ['global registry', () => EPackageRegistry.INSTANCE],
+  ['createPackageRegistry()', () => createPackageRegistry()],
+  ['getPackageRegistry()', () => getPackageRegistry()],
+  ['ExtensionAwarePackageRegistry', () => new ExtensionAwarePackageRegistry()],
+];
+
+describe('EPackageRegistry.registerPackage (#67)', () => {
+  afterEach(() => {
+    EPackageRegistry.INSTANCE.delete(NS_MAIN);
+    EPackageRegistry.INSTANCE.delete(NS_SUB);
+  });
+
+  describe.each(registries)('%s', (_label, makeRegistry) => {
+    it('should expose registerPackage', () => {
+      expect(typeof makeRegistry().registerPackage).toBe('function');
+    });
+
+    it('should register the package under its own nsURI', () => {
+      const registry = makeRegistry();
+      const pkg = createPackageWithSubpackage();
+
+      registry.registerPackage(pkg);
+
+      expect(registry.getEPackage(NS_MAIN)).toBe(pkg);
+    });
+
+    it('should register subpackages as well, like set() does', () => {
+      const registry = makeRegistry();
+      const pkg = createPackageWithSubpackage();
+
+      registry.registerPackage(pkg);
+
+      expect(registry.getEPackage(NS_SUB)?.getName()).toBe('sub');
+    });
+
+    it('should throw for a package without an nsURI', () => {
+      const registry = makeRegistry();
+      const pkg = new BasicEPackage();
+      pkg.setName('nameless');
+
+      expect(() => registry.registerPackage(pkg)).toThrow(/nsURI/);
+    });
+  });
+
+  it('should make the registered package resolvable through the ResourceSet', () => {
+    // The reported use case: register a package, then have the ResourceSet
+    // resolve references against it.
+    const resourceSet = new EResourceSetImpl();
+    const pkg = createPackageWithSubpackage();
+
+    resourceSet.getPackageRegistry().registerPackage(pkg);
+
+    expect(resourceSet.getPackageRegistry().getEPackage(NS_MAIN)).toBe(pkg);
+  });
+});


### PR DESCRIPTION
Fixes #65, #66, #67 and the actionable half of #68, reported against `0.1.1-next.16`. All four were reproduced against that exact tree before any change.

One commit per issue, so they can be reviewed - or reverted - independently.

## #65 — eGenericType left the feature without any eType

The Ecore metamodel had no features for generics at all: `ETypedElement` had no `eGenericType`, `EClassifier` had no `eTypeParameters`, and the `EGenericType` EClass was created without a single feature. The load reported three errors (the issue lists two - `eTypeParameters` on `EClass` was a third) while still appearing to succeed, and the feature silently ended up untyped.

- Adds the missing features: `ETypedElement.eGenericType`, `EClassifier.eTypeParameters`, `EClass.eGenericSuperTypes`, `EOperation.eTypeParameters`, `ETypeParameter.eBounds`, and the full `EGenericType` structure (`eClassifier`, `eTypeParameter`, `eTypeArguments`, `eUpperBound`, `eLowerBound`).
- Adds `BasicEGenericType` and `BasicETypeParameter`. The interfaces were exported all along but had no implementation anywhere.
- `getEType()` on `BasicEStructuralFeature`, `BasicEOperation` and `BasicEParameter` falls back to the raw type of its `eGenericType`, mirroring Java EMF where the eType of a generically typed element is derived rather than stored. `getERawType()` resolves a classifier reference directly and a type parameter through its first bound.
- `getETypeParameters()` on `BasicEClass` and `BasicEDataType` returned a hardcoded `[]` and is backed by a real field now.

The reported `Box<EString>` case loads without errors and **keeps its type arguments** - which the issue was willing to give up - and survives a save/load round trip, verified by a test asserting the serialized output.

## #66 — nested elements loaded as DynamicEObject

`EcoreFactory.create()` had no case for `EOperation` and `EParameter`, so both fell through to `DynamicEObject`.

- Adds `BasicEParameter`, which did not exist yet, and registers both classes in the factory.
- Two gaps beyond the report: `BasicEOperation.getEAnnotations()` was a stub returning `[]` and `getEAnnotation()` always returned `null`, so switching to the typed class alone would not have made annotations reachable. Both are backed by a real field now.
- Both classes override `eGet()`/`eSet()` to bind their declared fields to the reflective API. Without this the loader would write into the generic settings map while the typed accessors keep reading the private fields — the same class of mismatch that once made `BasicEAnnotation.eGet('details')` return a `Map` where the loader expected a pushable list.

## #67 — registerPackage() missing on a ResourceSet's registry

Moved into the `EPackageRegistry` interface; all five implementations provide it now (global registry, ResourceSet default, both ecore registries, and `ExtensionAwarePackageRegistry`, which the issue could not have known about).

`registerPackage()` delegates to `set()` everywhere, which also fixes a related inconsistency the parametrized test surfaced: `createPackageRegistry().set()` was the only implementation that did not register subpackages recursively. The helper doing that work was duplicated three times and is shared now.

A package without an nsURI throws rather than being silently dropped — the entry could never be looked up afterwards.

## #68 — partly: the additive half

**Point 2 (dist-tags)** is addressed: the README now leads with `npm install @emfts/core@next` and states that `latest` is `0.1.0` and predates the `@masagroup/ecore` compatibility layer under `src/ecore/`. Promoting the tag on npm stays a separate release decision. It also corrects the stated default branch, which is `snapshot` now.

**Point 1 (EList vs array)** gets the groundwork plus documentation, not the unification:

- `EList` declares `[index: number]: T`, and `BasicEList` installs the index-access Proxy in its own constructor, so every list supports `list[i]` however it was constructed. Writes route through `set()`/`add()`, so notifications still fire; assigning past the end throws instead of creating a sparse list.
- The `length` setter (truncate/clear) moved into the shared handler, so behaviour previously reachable only through `createIndexedProxy` now applies everywhere. `createIndexedProxy()` and `createEMap()` no longer stack a second Proxy on an already-wrapped list.
- Adds `concat`, `sort`, `reverse`, `join`, `at`, `lastIndexOf`, `flatMap`, `toJSON`. `sort`/`reverse` reorder through `move()` so each relocation emits a MOVE notification, mirroring `ECollections.sort()` rather than rewriting the backing array silently.
- `keys()`/`values()`/`entries()` are deliberately absent: `EMap extends EList` and defines `keys()` with map semantics, so an array-style `keys()` cannot coexist.
- New [`docs/collections.md`](../blob/fix/issues-65-68/docs/collections.md) with the accessor table the issue asked for.

`Array.isArray()` stays `false` and is pinned by a test. A list that guarantees notifications cannot be an array: inheriting from `Array` would expose the `length` setter and raw index assignment, both of which bypass every interceptor, and `Symbol.species` would make `map()`/`filter()` construct an `EList` with a length as its constructor argument. This is the `NodeList` position — indexable, iterable, not an array — with `Array.from(list)` as the documented escape hatch.

**Not included:** unifying the array-returning accessors (`getEOperations()`, `getESuperTypes()`, `getEAll*()`, `getEAnnotations()`) onto `EList`. That changes public return types and belongs in a major version rather than next to four bug fixes. Worth recording for whoever picks it up: the real work is not the 21 signatures but the 56 `Array.isArray()` checks across ten `Basic*` classes, mostly in `eSet` overrides of the form `if (Array.isArray(newValue)) { ... }` — each would silently swallow an `EList` assignment. Making those checks tolerant is additive and should land first.

## Corrections to my own analysis in #68

Two things I stated in the issue thread turned out to be wrong once measured against the code, both in the reassuring direction:

- **Index access was never broken.** `createIndexedProxy` already existed and every public accessor used it, so `getEClassifiers()[0]` worked all along; only directly constructed `new BasicEList()` returned `undefined`. The silent breakage I described as the main hazard of the unification does not exist.
- **`JSON.stringify` was worse, but for a different reason.** It threw `TypeError: Converting circular structure to JSON`. The cycle comes from the `EObject` elements (`_eContainer`), not from the list fields. `toJSON()` fixes it for lists of primitives; a list of EObjects still cannot be stringified directly, which the docs and a test now state.

## Verification

- `tsc` clean, `401 tests passing` in 18 files (baseline before this branch: 353 in 16).
- 48 new tests: `tests/EcoreMetamodelLoad.test.ts` (#65/#66 including the round trip), `tests/PackageRegistry.test.ts` (#67, parametrized over all five registry implementations), and 16 added to `tests/EList.test.ts` (#68, including `Array.isArray() === false` as a pinned contract).

## Also in here

`chore:` commit adds the CHANGELOG entry and fixes the CI workflow, which triggered on `branches: [main]` only — that branch no longer exists since the default became `snapshot`, so pull requests were running without any checks. It now triggers on both.

`package.json` is deliberately untouched: `publish.yml` derives the version from the release tag.
