### PR TITLE
fix: treat EEnum values as literals on XMI load and save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the `emfts` package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1-next.18] - 2026-08-14
+
+### Fixed
+
+- EEnum values in instance data are loaded as `EEnumLiteral` instead of raw strings ([#70](https://github.com/eclipse-fennec/emf.ts/issues/70)). `EFactory.createFromString()` had no EEnum branch, so an enum attribute ended up as the string from the file and an invalid value was accepted silently. The value is now resolved against the enum — by literal first, then by name, then by ordinal — and a value that matches none of them is reported in `resource.getErrors()` and leaves the feature unset, rather than being accepted or aborting the load.
+- `BasicEEnumLiteral.getLiteral()` falls back to the name when the `.ecore` declares no explicit `literal`, matching `EEnumLiteralImpl.getLiteral()` in Java EMF. Without the fallback a lookup by literal could not resolve anything for the majority of real `.ecore` files, where the attribute is omitted.
+- Enum attributes are serialized as their literal, not their name. `XMLSave` reached the generic EObject fallback and wrote `getName()`, which silently produced the wrong string whenever the literal differed from the name. Enum values now go through the factory, so a load/save cycle also normalizes a name or ordinal in the source file to the literal.
+
 ## [0.1.1-next.17] - 2026-08-14
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "emfts",
-  "version": "0.1.1-next.17",
+  "version": "0.1.1-next.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "emfts",
-      "version": "0.1.1-next.17",
+      "version": "0.1.1-next.18",
       "license": "EPL-2.0",
       "devDependencies": {
         "@commitlint/cli": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emfts/core",
-  "version": "0.1.1-next.17",
+  "version": "0.1.1-next.18",
   "description": "TypeScript interfaces for Eclipse EMF Core",
   "type": "module",
   "main": "dist/index.js",

--- a/src/runtime/BasicEEnumLiteral.ts
+++ b/src/runtime/BasicEEnumLiteral.ts
@@ -49,8 +49,13 @@ export class BasicEEnumLiteral extends BasicEObject implements EEnumLiteral {
     this.instance = value;
   }
 
+  /**
+   * Returns the literal string, falling back to the name when no explicit
+   * literal is set. In .ecore files the `literal` attribute is usually
+   * omitted, so without this fallback lookups by literal would never match.
+   */
   getLiteral(): string | null {
-    return this.literal;
+    return this.literal ?? this._name;
   }
 
   setLiteral(value: string | null): void {

--- a/src/runtime/DataTypeRegistry.ts
+++ b/src/runtime/DataTypeRegistry.ts
@@ -7,6 +7,9 @@
  */
 
 import { EDataType } from '../EDataType.js';
+import { EEnum } from '../EEnum.js';
+import { EEnumLiteral } from '../EEnumLiteral.js';
+import { isEEnum } from '../util/TypeGuards.js';
 
 /**
  * Converter interface for DataType serialization/deserialization
@@ -215,9 +218,27 @@ class DataTypeRegistryImpl {
   }
 
   /**
-   * Convert a string literal to a value using the DataType's converter
+   * Convert a string literal to a value using the DataType's converter.
+   *
+   * For an EEnum the string is resolved to the matching EEnumLiteral, and an
+   * invalid value throws - same as EFactoryImpl.createFromString in Java EMF.
+   * The XMI loader turns that throw into a resource error, so a single bad
+   * attribute does not abort the document (see XMLHandler.setFeatureValue).
    */
   createFromString(dataType: EDataType, literal: string): any {
+    if (isEEnum(dataType)) {
+      if (literal === null || literal === undefined) {
+        return null;
+      }
+      const eEnumLiteral = this.resolveEEnumLiteral(dataType, literal);
+      if (!eEnumLiteral) {
+        throw new Error(
+          `The value '${literal}' is not a valid enumerator of '${dataType.getName()}'`
+        );
+      }
+      return eEnumLiteral.getInstance() ?? eEnumLiteral;
+    }
+
     const converter = this.getConverter(dataType);
     if (converter) {
       return converter.fromString(literal);
@@ -227,11 +248,22 @@ class DataTypeRegistryImpl {
   }
 
   /**
-   * Convert a value to a string literal using the DataType's converter
+   * Convert a value to a string literal using the DataType's converter.
+   *
+   * For an EEnum the literal string is written, not the name - Java EMF
+   * serializes enum values via EEnumLiteralImpl.toString(), which is getLiteral().
    */
   convertToString(dataType: EDataType, value: any): string {
     if (value === null || value === undefined) {
       return '';
+    }
+
+    if (isEEnum(dataType)) {
+      const eEnumLiteral = this.findEEnumLiteral(dataType, value);
+      if (eEnumLiteral) {
+        return eEnumLiteral.getLiteral() ?? '';
+      }
+      // Unknown value - fall through to String(), like Java's objectValue.toString()
     }
 
     const converter = this.getConverter(dataType);
@@ -240,6 +272,52 @@ class DataTypeRegistryImpl {
     }
     // Default: use String()
     return String(value);
+  }
+
+  /**
+   * Resolve a serialized enum value to its EEnumLiteral.
+   *
+   * Java EMF only ever looks up by literal. We additionally accept the name
+   * and the ordinal, because both are unambiguous and both occur in files
+   * written by non-conforming serializers - rejecting them would make those
+   * models unloadable for no gain. Saving always writes the literal back, so
+   * a load/save cycle normalizes the file.
+   */
+  private resolveEEnumLiteral(eEnum: EEnum, literal: string): EEnumLiteral | null {
+    const byLiteral = eEnum.getEEnumLiteralByLiteral(literal);
+    if (byLiteral) {
+      return byLiteral;
+    }
+
+    // Name lookup: relevant when the enum declares an explicit `literal` but
+    // the file carries the name instead.
+    const byName = eEnum.getEEnumLiteral(literal);
+    if (byName) {
+      return byName;
+    }
+
+    const trimmed = literal.trim();
+    if (/^-?\d+$/.test(trimmed)) {
+      return eEnum.getEEnumLiteral(Number(trimmed));
+    }
+
+    return null;
+  }
+
+  /**
+   * Resolve an enum value to its EEnumLiteral. Accepts the literal itself as
+   * well as the `instance` a generated enum carries.
+   */
+  private findEEnumLiteral(eEnum: EEnum, value: any): EEnumLiteral | null {
+    if (value && typeof value === 'object' && typeof value.getLiteral === 'function') {
+      return value as EEnumLiteral;
+    }
+    for (const eEnumLiteral of eEnum.getELiterals()) {
+      if (eEnumLiteral.getInstance() === value) {
+        return eEnumLiteral;
+      }
+    }
+    return null;
   }
 
   /**

--- a/src/xmi/XMLHandler.ts
+++ b/src/xmi/XMLHandler.ts
@@ -873,12 +873,21 @@ export class XMLHandler {
           }
         }
       }
-      if (eFactory && dataType) {
-        const convertedValue = eFactory.createFromString(dataType, value);
-        this.helper.setValue(eObject, feature, convertedValue, position);
-      } else {
-        // Fallback: just use the string value directly for basic types
-        this.helper.setValue(eObject, feature, value, position);
+      // A value the datatype cannot convert must not abort the whole document.
+      // Java EMF collects such failures as IllegalValueException in
+      // resource.getErrors() and keeps loading (XMLHandler.setFeatureValue);
+      // the feature then stays unset.
+      try {
+        if (eFactory && dataType) {
+          const convertedValue = eFactory.createFromString(dataType, value);
+          this.helper.setValue(eObject, feature, convertedValue, position);
+        } else {
+          // Fallback: just use the string value directly for basic types
+          this.helper.setValue(eObject, feature, value, position);
+        }
+      } catch (e) {
+        const reason = e instanceof Error ? e.message : String(e);
+        this.error(`Invalid value for feature '${feature.getName()}': ${reason}`);
       }
     } else {
       // It's a reference - handle as ID

--- a/src/xmi/XMLSave.ts
+++ b/src/xmi/XMLSave.ts
@@ -18,6 +18,7 @@ import { URI } from '../URI.js';
 import { XMLHelper, XMLHelperImpl } from './XMLHelper.js';
 import { XSI_URI, XMI_URI } from './XMLHandler.js';
 import { isEList } from '../EList.js';
+import { isEEnum } from '../util/TypeGuards.js';
 import { InternalEObject, isInternalEObject } from '../InternalEObject.js';
 import {
   ExtendedMetaData,
@@ -821,6 +822,23 @@ export class XMLSave {
   protected convertToString(attr: EAttribute, value: any): string {
     if (value === null || value === undefined) return '';
 
+    // Handle arrays (multi-valued attributes) - serialize as space-separated values
+    if (Array.isArray(value) || isEList(value)) {
+      const items: string[] = [];
+      for (const item of value) {
+        if (item !== null && item !== undefined) {
+          items.push(this.convertSingleValueToString(attr, item));
+        }
+      }
+      return items.join(' ');
+    }
+
+    // Enum values must go through the factory, which writes the literal. The
+    // generic EObject fallback below would write getName() instead.
+    if (isEEnum(attr.getEType())) {
+      return this.convertSingleValueToString(attr, value);
+    }
+
     // If value is already a string (e.g., from unresolved proxy URI), return it
     if (typeof value === 'string') {
       return value;
@@ -834,17 +852,6 @@ export class XMLSave {
     // Handle numbers
     if (typeof value === 'number') {
       return String(value);
-    }
-
-    // Handle arrays (multi-valued attributes) - serialize as space-separated values
-    if (Array.isArray(value) || isEList(value)) {
-      const items: string[] = [];
-      for (const item of value) {
-        if (item !== null && item !== undefined) {
-          items.push(this.convertSingleValueToString(attr, item));
-        }
-      }
-      return items.join(' ');
     }
 
     // Handle EObject values (shouldn't happen for attributes, but just in case)
@@ -876,9 +883,14 @@ export class XMLSave {
    */
   protected convertSingleValueToString(attr: EAttribute, value: any): string {
     if (value === null || value === undefined) return '';
-    if (typeof value === 'string') return value;
-    if (typeof value === 'boolean') return value ? 'true' : 'false';
-    if (typeof value === 'number') return String(value);
+
+    // Enums are resolved to their literal by the factory, never shortcut here
+    const isEnum = isEEnum(attr.getEType());
+    if (!isEnum) {
+      if (typeof value === 'string') return value;
+      if (typeof value === 'boolean') return value ? 'true' : 'false';
+      if (typeof value === 'number') return String(value);
+    }
 
     const eType = attr.getEType();
     if (eType && 'getEPackage' in eType) {

--- a/tests/EEnumValue.test.ts
+++ b/tests/EEnumValue.test.ts
@@ -1,0 +1,217 @@
+/**
+ * @fileoverview EEnum Value Tests - Enum-Werte in Instanzdaten (Issue #70)
+ *
+ * Testet, dass Enum-Attribute beim Laden zu EEnumLiteral aufgeloest und beim
+ * Speichern als Literal-String geschrieben werden - konform zu Java EMF
+ * (EFactoryImpl.createFromString / EEnumLiteralImpl.getLiteral).
+ *
+ * @module tests/EEnumValue
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { XMIResource } from '../src/xmi/XMLResource';
+import { URI } from '../src/URI';
+import { BasicResourceSet } from '../src/runtime/BasicResourceSet';
+import { getEcorePackage, ECORE_NS_URI } from '../src/ecore/EcorePackage';
+import { EPackage } from '../src/EPackage';
+import { EClass } from '../src/EClass';
+import { EEnum } from '../src/EEnum';
+import { EObject } from '../src/EObject';
+
+const NS = 'http://example.com/mymodel';
+
+/**
+ * Ecore mit einem EEnum, dessen zweites Literal ein vom Namen abweichendes
+ * `literal` traegt - genau der Fall, den der getName()-Fallback falsch macht.
+ */
+const ECORE_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<ecore:EPackage xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmi:version="2.0"
+    name="mymodel" nsURI="${NS}" nsPrefix="my">
+  <eClassifiers xsi:type="ecore:EEnum" name="Color">
+    <eLiterals name="RED"/>
+    <eLiterals name="GREEN" value="1" literal="green_literal"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Item">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="color" eType="#//Color"/>
+  </eClassifiers>
+</ecore:EPackage>`;
+
+describe('EEnum values in instance data (Issue #70)', () => {
+  let resourceSet: BasicResourceSet;
+  let modelPackage: EPackage;
+  let itemClass: EClass;
+  let colorEnum: EEnum;
+
+  beforeEach(async () => {
+    getEcorePackage();
+    resourceSet = new BasicResourceSet();
+    resourceSet.getPackageRegistry().set(ECORE_NS_URI, getEcorePackage());
+
+    const ecoreResource = new XMIResource(URI.createURI('test://model.ecore'));
+    ecoreResource.setResourceSet(resourceSet);
+    await ecoreResource.loadFromString(ECORE_XML);
+
+    modelPackage = ecoreResource.getContents()[0] as EPackage;
+    resourceSet.getPackageRegistry().set(NS, modelPackage);
+
+    itemClass = modelPackage.getEClassifier('Item') as EClass;
+    colorEnum = modelPackage.getEClassifier('Color') as EEnum;
+  });
+
+  /**
+   * Laedt eine Instanz mit dem gegebenen color-Wert.
+   */
+  async function loadResource(colorValue: string): Promise<XMIResource> {
+    const resource = new XMIResource(URI.createURI('test://inst.xmi'));
+    resource.setResourceSet(resourceSet);
+    await resource.loadFromString(
+      `<?xml version="1.0" encoding="UTF-8"?>\n` +
+        `<my:Item xmlns:xmi="http://www.omg.org/XMI" xmlns:my="${NS}" ` +
+        `xmi:version="2.0" color="${colorValue}"/>`
+    );
+    return resource;
+  }
+
+  async function loadItem(colorValue: string): Promise<EObject> {
+    return (await loadResource(colorValue)).getContents()[0];
+  }
+
+  function getColor(item: EObject): any {
+    return item.eGet(item.eClass().getEStructuralFeature('color')!);
+  }
+
+  describe('getLiteral() name fallback', () => {
+    it('falls back to the name when no literal attribute is set', () => {
+      const red = colorEnum.getEEnumLiteral('RED')!;
+      expect(red.getLiteral()).toBe('RED');
+    });
+
+    it('keeps an explicit literal that differs from the name', () => {
+      const green = colorEnum.getEEnumLiteral('GREEN')!;
+      expect(green.getName()).toBe('GREEN');
+      expect(green.getLiteral()).toBe('green_literal');
+    });
+
+    it('resolves both literals via getEEnumLiteralByLiteral', () => {
+      expect(colorEnum.getEEnumLiteralByLiteral('RED')?.getName()).toBe('RED');
+      expect(colorEnum.getEEnumLiteralByLiteral('green_literal')?.getName()).toBe('GREEN');
+    });
+  });
+
+  describe('load', () => {
+    it('resolves a literal without an explicit literal attribute', async () => {
+      const value = getColor(await loadItem('RED'));
+      expect(typeof value).toBe('object');
+      expect(value.getName()).toBe('RED');
+      expect(value.getValue()).toBe(0);
+    });
+
+    it('resolves an explicit literal to its EEnumLiteral', async () => {
+      const value = getColor(await loadItem('green_literal'));
+      expect(typeof value).toBe('object');
+      expect(value.getName()).toBe('GREEN');
+      expect(value.getValue()).toBe(1);
+    });
+
+    it('accepts the name when the enum declares a different literal', async () => {
+      const value = getColor(await loadItem('GREEN'));
+      expect(value.getName()).toBe('GREEN');
+      expect(value.getValue()).toBe(1);
+    });
+
+    it('accepts an ordinal value', async () => {
+      const value = getColor(await loadItem('1'));
+      expect(value.getName()).toBe('GREEN');
+      expect(value.getValue()).toBe(1);
+    });
+
+    it('rejects an ordinal outside the enum', async () => {
+      const resource = await loadResource('7');
+      expect(getColor(resource.getContents()[0]) ?? null).toBeNull();
+      expect(resource.getErrors()).toHaveLength(1);
+    });
+
+    it('reports an unknown value instead of accepting it silently', async () => {
+      const resource = await loadResource('PURPLE');
+      const errors = resource.getErrors();
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toMatch(
+        /The value 'PURPLE' is not a valid enumerator of 'Color'/
+      );
+    });
+
+    it('keeps loading after an invalid value, leaving the feature unset', async () => {
+      const resource = await loadResource('PURPLE');
+      const item = resource.getContents()[0];
+      expect(item).toBeDefined();
+      expect(item.eClass().getName()).toBe('Item');
+      expect(getColor(item) ?? null).toBeNull();
+    });
+  });
+
+  describe('save', () => {
+    /**
+     * Speichert eine frisch erzeugte Item-Instanz mit dem gegebenen Farbwert.
+     */
+    async function saveWithColor(colorValue: any): Promise<string> {
+      const factory = modelPackage.getEFactoryInstance()!;
+      const item = factory.create(itemClass);
+      item.eSet(itemClass.getEStructuralFeature('color')!, colorValue);
+
+      const resource = new XMIResource(URI.createURI('test://out.xmi'));
+      resource.setResourceSet(resourceSet);
+      resource.getContents().push(item);
+      return resource.saveToString();
+    }
+
+    it('writes the literal, not the name', async () => {
+      const green = colorEnum.getEEnumLiteral('GREEN')!;
+      const xml = await saveWithColor(green);
+      expect(xml).toContain('color="green_literal"');
+      expect(xml).not.toContain('color="GREEN"');
+    });
+
+    it('writes the name when it doubles as the literal', async () => {
+      const red = colorEnum.getEEnumLiteral('RED')!;
+      const xml = await saveWithColor(red);
+      expect(xml).toContain('color="RED"');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('preserves an explicit literal through load and save', async () => {
+      const item = await loadItem('green_literal');
+
+      const resource = new XMIResource(URI.createURI('test://roundtrip.xmi'));
+      resource.setResourceSet(resourceSet);
+      resource.getContents().push(item);
+      const xml = await resource.saveToString();
+
+      expect(xml).toContain('color="green_literal"');
+    });
+
+    it('normalizes an ordinal to the literal on save', async () => {
+      const item = await loadItem('1');
+
+      const resource = new XMIResource(URI.createURI('test://roundtrip.xmi'));
+      resource.setResourceSet(resourceSet);
+      resource.getContents().push(item);
+      const xml = await resource.saveToString();
+
+      expect(xml).toContain('color="green_literal"');
+      expect(xml).not.toContain('color="1"');
+    });
+
+    it('preserves a name-only literal through load and save', async () => {
+      const item = await loadItem('RED');
+
+      const resource = new XMIResource(URI.createURI('test://roundtrip.xmi'));
+      resource.setResourceSet(resourceSet);
+      resource.getContents().push(item);
+      const xml = await resource.saveToString();
+
+      expect(xml).toContain('color="RED"');
+    });
+  });
+});


### PR DESCRIPTION
Closes #70. Version bumped to `0.1.1-next.18`.

## Problem

`EFactory.createFromString()` had no EEnum branch, so an enum attribute was loaded as the **raw string** from the file and an invalid value was accepted without a word — no exception, no entry in `getErrors()`. The bug only surfaced in the application: empty dropdowns, broken round-trips, files Java EMF refuses to load.

Saving happened to work only by accident: `XMLSave.convertToString()` reached its generic EObject fallback and wrote `getName()`. That is correct exactly as long as the literal equals the name, and wrong as soon as the `.ecore` declares its own — the fallback sits *before* the factory call, so fixing the factory alone would not have changed the output.

## Changes

**`DataTypeRegistry.createFromString()`** resolves the value against the enum and returns the `EEnumLiteral`; **`convertToString()`** writes `getLiteral()`.

Java EMF looks up by literal only (`EFactoryImpl.java:310`). We additionally accept the **name** and the **ordinal**, because both are unambiguous and both occur in files written by non-conforming serializers — rejecting them would make those models unloadable for no gain. Saving always writes the literal back, so a load/save cycle normalizes the file.

**Invalid values are visible, not fatal.** The factory throws like Java does, but `XMLHandler.setFeatureValue()` catches it and records it in `resource.getErrors()` with the feature left unset. One bad attribute no longer aborts the whole document.

**`BasicEEnumLiteral.getLiteral()`** falls back to the name when no explicit `literal` is set, matching `EEnumLiteralImpl.getLiteral()`. Without it a lookup by literal resolves nothing for the majority of real `.ecore` files, where the attribute is omitted. `eGet('literal')` still returns the raw value, so saving an `.ecore` does not invent a `literal` attribute where none stood.

**`XMLSave`** runs enum values through the factory before the string/boolean/number shortcuts and before the EObject fallback. The array check moved up accordingly — behaviour-neutral, since an array is never one of those primitives.

## Behaviour

For an enum `Color { RED, GREEN(1, literal="green_literal") }`:

| Case | Before | After |
|---|---|---|
| load `color="green_literal"` | `"green_literal"` (string) | `EEnumLiteral` GREEN |
| load `color="GREEN"` | `"GREEN"` (string) | `EEnumLiteral` GREEN |
| load `color="1"` | `"1"` (string) | `EEnumLiteral` GREEN |
| load `color="PURPLE"` | `"PURPLE"` (string), no errors | unset + entry in `getErrors()` |
| save `EEnumLiteral` GREEN | `color="GREEN"` | `color="green_literal"` |
| round-trip of `color="1"` | `color="1"` | `color="green_literal"` |

## Tests

New `tests/EEnumValue.test.ts` (15 tests) covers the name fallback, all load cases above, both save cases and the round-trip normalization. Full suite: **416 tests green**, `tsc --noEmit` clean.
