### PR TITLE
feat!: unify all multi-valued accessors on EList, with cached read-only derived lists (#68)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,12 @@ jobs:
       - name: Build
         run: npm run build
 
+      # `npm test` runs vitest in watch mode; it only terminates here because
+      # vitest detects CI. Calling the explicit run script instead means the job
+      # cannot hang if that detection ever changes.
+      # The github-actions reporter annotates failing tests in the PR diff.
       - name: Test
-        run: npm test
+        run: npm run test:run -- --reporter=default --reporter=github-actions
 
       - name: Upload build artifacts
         if: matrix.node-version == 22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to the `emfts` package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed — BREAKING
+
+- **Every multi-valued accessor returns `EList<T>` instead of `T[]`** ([#68](https://github.com/eclipse-fennec/emf.ts/issues/68)). Java EMF returns an `EList` throughout; the mixed returns were a conformance gap and, per the report, the single most frequent porting mistake. Affects 21 accessors across 10 interfaces: `EClass` (`getESuperTypes`, `getEAllSuperTypes`, `getEAllStructuralFeatures`, `getEAttributes`, `getEAllAttributes`, `getEReferences`, `getEAllReferences`, `getEAllContainments`, `getEOperations`, `getEAllOperations`), `EOperation` (`getEParameters`, `getEExceptions`), `EAnnotation` (`getContents`, `getReferences`), `EModelElement` (`getEAnnotations`), `EEnum` (`getELiterals`), `EClassifier` (`getETypeParameters`), `ETypeParameter` (`getEBounds`), `EGenericType` (`getETypeArguments`), `EReference` (`getEKeys`), `ResourceSet` (`getResources`).
+
+  Most consumer code keeps working, because `EList` carries the array API: `length`, `list[i]`, `map`/`filter`/`find`/`some`/`every`/`reduce`, `push`/`pop`/`splice`, `sort`/`reverse`, spread, destructuring and `for...of`. Two things need attention:
+
+  - `Array.isArray(result)` is now `false`. The normalizing idiom `Array.isArray(v) ? v : [v]` takes the wrong branch — use the exported `isListValue(v)` / `toArray(v)` instead.
+  - Passing a result where a real array is required needs `Array.from(result)`.
+
+  See [docs/collections.md](./docs/collections.md) for the full migration notes.
+
+- **Derived accessors are read-only.** `getEAll*()`, `getEAttributes()`, `getEReferences()` and `getEAllContainments()` assemble their result from the class and its supertypes, so writing into it could never have an effect. Mutating methods now throw an `Error` naming the accessor, mirroring `EcoreEList.UnmodifiableEList` in Java EMF, which throws `UnsupportedOperationException`. Previously such a write appeared to succeed and was silently lost.
+
+### Added
+
+- Derived lists are cached and invalidated by a metamodel revision counter. Measured on a five-level hierarchy with 50 features: `getEAllStructuralFeatures()` drops from 3.4 µs to 0.31 µs per call, and repeated calls return the identical list object while the model is unchanged, as they do in Java EMF. Invalidation is transitive — adding a feature to a grandparent class refreshes its descendants' lists.
+- `UnmodifiableEList`, `MetamodelEList`, `createUnmodifiableEList()`, `createMetamodelEList()`, `isListValue()`, `toArray()`, `replaceListContents()`, `bumpMetamodelRevision()`, `currentMetamodelRevision()`, `cachedDerivedList()`.
+
+### Fixed
+
+- `getEAnnotations()` on `BasicEPackage`, `BasicEFactory` and `BasicEAnnotation` returned a hardcoded `[]`, so annotations on packages, factories and annotations themselves were unreachable — the same stub pattern that [#66](https://github.com/eclipse-fennec/emf.ts/issues/66) uncovered on `BasicEOperation`.
+- `filter`, `find`, `findIndex`, `some` and `every` on `EList` accept a predicate returning `unknown` rather than `boolean`, matching how TypeScript types `Array.prototype`. Callbacks of the form `x && y` type-check again.
+
 ## [0.1.1-next.18] - 2026-08-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the `emfts` package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.0-next.1] - 2026-08-14
 
 ### Changed — BREAKING
 

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ console.log(name); // 'John Doe'
 
 ## Documentation
 
-- [Collections: EList, EMap and arrays](./docs/collections.md) — which accessors
-  return an `EList` and which return a plain array, and why `Array.isArray()` is
-  `false` on an `EList`
+- [Collections: EList and EMap](./docs/collections.md) — owned versus derived
+  lists, the array API available on an `EList`, why `Array.isArray()` is `false`,
+  and how to migrate code written against the earlier array returns
 - [Examples](./docs/examples/index.md) — dynamic models, factories, notifications,
   XMI/JSON persistence
 

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -1,126 +1,140 @@
-# Collections: EList, EMap and arrays
+# Collections: EList and EMap
 
-Multi-valued features are returned either as an `EList` or as a plain array,
-depending on the accessor. This page says which is which, and what an `EList`
-guarantees that an array cannot.
+Every multi-valued accessor returns an `EList`, as in Java EMF. This page covers
+the two flavours you will meet, what an `EList` guarantees that an array cannot,
+and how to migrate code written against the earlier array returns.
 
-## Which accessor returns what
+## Owned versus derived lists
 
-`EList` accessors are the ones that own their contents: mutating them updates the
-model and emits notifications. Array accessors are either derived views
-(`getEAll*`, filtered variants) or lists that have not been migrated yet.
+| | example | writable |
+|---|---|---|
+| **Owned** — the list holds the contents | `getEStructuralFeatures()`, `getEOperations()`, `getESuperTypes()`, `getEClassifiers()`, `getEParameters()`, `getELiterals()` | yes |
+| **Derived** — assembled from the class and its supertypes | `getEAllStructuralFeatures()`, `getEAllSuperTypes()`, `getEAttributes()`, `getEReferences()`, `getEAllAttributes()`, `getEAllReferences()`, `getEAllContainments()`, `getEAllOperations()` | **no** |
 
-| Accessor | Returns |
-|---|---|
-| `EPackage.getEClassifiers()` | `EList<EClassifier>` |
-| `EPackage.getESubpackages()` | `EList<EPackage>` |
-| `EClass.getEStructuralFeatures()` | `EList<EStructuralFeature>` |
-| `Resource.getContents()` | `EList<EObject>` |
-| `EAnnotation.getDetails()` | `EMap<string, string>` |
-| `EClass.getESuperTypes()` | `EClass[]` |
-| `EClass.getEAllSuperTypes()` | `EClass[]` |
-| `EClass.getEAllStructuralFeatures()` | `EStructuralFeature[]` |
-| `EClass.getEAttributes()` / `getEAllAttributes()` | `EAttribute[]` |
-| `EClass.getEReferences()` / `getEAllReferences()` | `EReference[]` |
-| `EClass.getEAllContainments()` | `EReference[]` |
-| `EClass.getEOperations()` / `getEAllOperations()` | `EOperation[]` |
-| `EClassifier.getETypeParameters()` | `ETypeParameter[]` |
-| `EOperation.getEParameters()` | `EParameter[]` |
-| `EOperation.getEExceptions()` | `EClassifier[]` |
-| `EEnum.getELiterals()` | `EEnumLiteral[]` |
-| `EModelElement.getEAnnotations()` | `EAnnotation[]` |
-| `EAnnotation.getContents()` / `getReferences()` | `EObject[]` |
-| `ETypeParameter.getEBounds()` | `EGenericType[]` |
-| `EGenericType.getETypeArguments()` | `EGenericType[]` |
-| `ResourceSet.getResources()` | `Resource[]` |
+Writing into a derived list cannot have an effect - it is assembled on demand -
+so instead of failing silently it throws:
 
-Java EMF returns an `EList` throughout, so the array returns are a known
-deviation; the intent is to unify on `EList` in a future major version. Writing
-code that works with either is straightforward, because the two overlap far more
-than they differ - see below.
+```ts
+eClass.getEAllStructuralFeatures().add(feature)
+// Error: Cannot call add() on the result of getEAllStructuralFeatures():
+//        it is a derived list and cannot be modified.
+//        Modify the owning list instead (e.g. getEStructuralFeatures()).
 
-## Writing code that works with both
+eClass.getEStructuralFeatures().add(feature)   // this is the way
+```
 
-An `EList` supports the array API you are likely to reach for:
+This matches `EcoreEList.UnmodifiableEList` in Java EMF, whose mutating methods
+throw `UnsupportedOperationException`.
+
+Derived lists are cached and returned as the identical object while the metamodel
+is unchanged, again as in Java EMF:
+
+```ts
+eClass.getEAllStructuralFeatures() === eClass.getEAllStructuralFeatures()  // true
+```
+
+The cache is invalidated by any structural change, including changes several
+levels up the inheritance chain — adding a feature to a grandparent class
+refreshes its descendants' derived lists.
+
+## The array API on EList
+
+An `EList` supports the array surface you are likely to reach for:
 
 ```ts
 list.length          // and size()
 list[0]              // and get(0)
+list[list.length] = x  // appends, like add()
 list.map(fn)         // filter, forEach, find, findIndex, some, every,
                      // slice, reduce, includes, indexOf, lastIndexOf,
                      // concat, join, at, flatMap
 list.push(x)         // pop, shift, unshift, splice
-list.sort(cmp)       // reverse
+list.sort(cmp)       // reverse — both emit MOVE notifications
+list.length = 0      // clears, like clear()
 for (const x of list) { /* ... */ }
 const [first] = list
 const copy = [...list]
 JSON.stringify(list) // -> [...]
 ```
 
-Two idioms need care:
-
-```ts
-// Works on an EList, but NOT on an array:
-list.size()
-
-// Works on an array, but NOT on an EList:
-Array.isArray(value)
-```
-
-If you need one shape regardless of what an accessor gave you, normalize with
-`Array.from()`, which works on both:
-
-```ts
-const features = Array.from(eClass.getEAllStructuralFeatures())
-```
+Not available: `keys()`, `values()` and `entries()`. `EMap` extends `EList` and
+defines `keys()` with map semantics, so the array-style iterators cannot coexist
+on the same type. Use `Array.from(list).keys()`.
 
 ## EList is not an Array - deliberately
 
 `Array.isArray(eList)` returns `false`, and that will not change.
 
-An `EList` is a `NotifyingEList`: every mutation emits a notification, which is
-what adapters and `EContentAdapter` rely on. A real Array cannot keep that
-promise, because it exposes two write paths that no interceptor can see:
+An `EList` is a `NotifyingEList`: every mutation emits a notification, which
+adapters and `EContentAdapter` depend on. A real Array cannot keep that promise,
+because it exposes two write paths no interceptor can see:
 
 ```ts
 list.length = 0      // would empty the list
 list[5] = value      // would write a raw slot
 ```
 
-`EList` supports both of these expressions, but routes them through `clear()`,
-`removeAt()` and `set()` so that notifications still fire. Inheriting from
-`Array` would hand out the native versions instead and silently break the
-contract. Array subclasses also construct their own type via `Symbol.species`,
-so `map()` and `filter()` would try to build an `EList` with an array length as
-its constructor argument.
+`EList` supports both expressions but routes them through `clear()`,
+`removeAt()` and `set()` so notifications still fire. Inheriting from `Array`
+would hand out the native versions instead. Array subclasses also construct
+their own type through `Symbol.species`, so `map()` and `filter()` would try to
+build an `EList` with an array length as its constructor argument.
 
 This is the position `NodeList`, `HTMLCollection`, `FileList` and `arguments`
-have held in the DOM for decades: indexable, iterable, with a `length` - and not
+have held in the DOM for decades: indexable, iterable, with a `length` — and not
 an array. `Array.from(list)` is the documented way to get a real one.
 
-Note that assigning past the end throws instead of creating a sparse list:
+Assigning past the end throws rather than creating a sparse list:
 
 ```ts
-const list = eClass.getEStructuralFeatures()  // size 2
-list[2] = feature   // appends, same as add()
-list[7] = feature   // RangeError - use add() or push()
+const features = eClass.getEStructuralFeatures()   // size 2
+features[2] = feature   // appends, same as add()
+features[7] = feature   // RangeError — use add() or push()
 ```
+
+## Migrating from the array returns
+
+Most code needs no change, because the array API above keeps working. Two things
+do need attention:
+
+**1. `Array.isArray()` checks.** The common normalizing idiom now takes the wrong
+branch and would treat a list as a single value:
+
+```ts
+// before — wraps the EList in a one-element array
+const items = Array.isArray(value) ? value : [value]
+
+// after
+import { isListValue, toArray } from '@emfts/core'
+const items = isListValue(value) ? toArray(value) : [value]
+```
+
+**2. Passing a result where an array is required.** Anything with an `Array`
+parameter type, or a library that checks for a real array, needs a conversion:
+
+```ts
+someLibrary(Array.from(eClass.getEAllStructuralFeatures()))
+```
+
+Helpers exported for this purpose:
+
+| | |
+|---|---|
+| `isEList(v)` | true for an `EList` |
+| `isListValue(v)` | true for an `EList` **or** a plain array |
+| `toArray(v)` | normalizes either shape to a plain array |
+| `replaceListContents(list, v)` | refills an owned list from an array, `EList` or iterable |
 
 ## Serialization
 
-`JSON.stringify(list)` produces a plain array. This works for lists of primitive
+`JSON.stringify(list)` produces a plain array. That works for lists of primitive
 values; a list of `EObject`s still cannot be stringified directly, because
 `EObject`s reference their container and are therefore cyclic. Use the JSON
-resource support for models - see [examples/Persistence.md](./examples/Persistence.md).
+resource support for models — see [examples/Persistence.md](./examples/Persistence.md).
 
 ## EMap
 
-`EAnnotation.getDetails()` returns an `EMap<K, V>`, which is an `EList` of map
-entries plus map operations (`getByKey`, `putByKey`, `removeByKey`,
-`containsKey`, `keys`, `mapValues`, `toMap`). This mirrors Java EMF, where
-`EMap<K,V>` extends `EList<Map.Entry<K,V>>`.
-
-Because `EMap.keys()` returns the map keys, `EList` deliberately does not declare
-the array-style `keys()`/`values()`/`entries()` iterators - the two meanings
-cannot coexist on one type. Use `Array.from(list).keys()` if you need the
-array-style iterator.
+`EAnnotation.getDetails()` returns an `EMap<K, V>`: an `EList` of map entries
+plus map operations (`getByKey`, `putByKey`, `removeByKey`, `containsKey`,
+`keys`, `mapValues`, `toMap`). This mirrors Java EMF, where `EMap<K,V>` extends
+`EList<Map.Entry<K,V>>`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "emfts",
-  "version": "0.1.1-next.18",
+  "version": "0.2.0-next.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "emfts",
-      "version": "0.1.1-next.18",
+      "version": "0.2.0-next.1",
       "license": "EPL-2.0",
       "devDependencies": {
         "@commitlint/cli": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emfts/core",
-  "version": "0.1.1-next.18",
+  "version": "0.2.0-next.1",
   "description": "TypeScript interfaces for Eclipse EMF Core",
   "type": "module",
   "main": "dist/index.js",

--- a/src/EAnnotation.ts
+++ b/src/EAnnotation.ts
@@ -9,6 +9,7 @@
 import { EModelElement } from './EModelElement.js';
 import { EObject } from './EObject.js';
 import { EMap } from './EMap.js';
+import { EList } from './EList.js';
 
 /**
  * A representation of the model object 'EAnnotation'.
@@ -43,10 +44,10 @@ export interface EAnnotation extends EModelElement {
   /**
    * Returns the list of contents (arbitrary EObjects).
    */
-  getContents(): EObject[];
+  getContents(): EList<EObject>;
 
   /**
    * Returns the list of references (arbitrary EObjects).
    */
-  getReferences(): EObject[];
+  getReferences(): EList<EObject>;
 }

--- a/src/EClass.ts
+++ b/src/EClass.ts
@@ -41,12 +41,15 @@ export interface EClass extends EClassifier {
   /**
    * Returns the list of super types.
    */
-  getESuperTypes(): EClass[];
+  getESuperTypes(): EList<EClass>;
 
   /**
-   * Returns the list of all super types (transitive closure).
+   * Returns all super types (transitive closure).
+   *
+   * Derived: the list is assembled from this class and its supertypes, so it is
+   * read-only - mutating methods throw. Modify getESuperTypes() instead.
    */
-  getEAllSuperTypes(): EClass[];
+  getEAllSuperTypes(): EList<EClass>;
 
   /**
    * Returns the ID attribute, or null.
@@ -63,44 +66,65 @@ export interface EClass extends EClassifier {
   getEStructuralFeatures(): EList<EStructuralFeature>;
 
   /**
-   * Returns the list of all structural features (including inherited).
+   * Returns all structural features, including inherited ones.
+   *
+   * Derived: the list is assembled from this class and its supertypes, so it is
+   * read-only - mutating methods throw. Modify getEStructuralFeatures() instead.
    */
-  getEAllStructuralFeatures(): EStructuralFeature[];
+  getEAllStructuralFeatures(): EList<EStructuralFeature>;
 
   /**
-   * Returns the list of attributes of this class only.
+   * Returns the attributes of this class only.
+   *
+   * Derived: the list is assembled from this class and its supertypes, so it is
+   * read-only - mutating methods throw. Modify getEStructuralFeatures() instead.
    */
-  getEAttributes(): EAttribute[];
+  getEAttributes(): EList<EAttribute>;
 
   /**
-   * Returns the list of all attributes (including inherited).
+   * Returns all attributes, including inherited ones.
+   *
+   * Derived: the list is assembled from this class and its supertypes, so it is
+   * read-only - mutating methods throw. Modify getEStructuralFeatures() instead.
    */
-  getEAllAttributes(): EAttribute[];
+  getEAllAttributes(): EList<EAttribute>;
 
   /**
-   * Returns the list of references of this class only.
+   * Returns the references of this class only.
+   *
+   * Derived: the list is assembled from this class and its supertypes, so it is
+   * read-only - mutating methods throw. Modify getEStructuralFeatures() instead.
    */
-  getEReferences(): EReference[];
+  getEReferences(): EList<EReference>;
 
   /**
-   * Returns the list of all references (including inherited).
+   * Returns all references, including inherited ones.
+   *
+   * Derived: the list is assembled from this class and its supertypes, so it is
+   * read-only - mutating methods throw. Modify getEStructuralFeatures() instead.
    */
-  getEAllReferences(): EReference[];
+  getEAllReferences(): EList<EReference>;
 
   /**
-   * Returns the list of all containment references.
+   * Returns all containment references.
+   *
+   * Derived: the list is assembled from this class and its supertypes, so it is
+   * read-only - mutating methods throw. Modify getEStructuralFeatures() instead.
    */
-  getEAllContainments(): EReference[];
+  getEAllContainments(): EList<EReference>;
 
   /**
    * Returns the list of operations of this class only.
    */
-  getEOperations(): EOperation[];
+  getEOperations(): EList<EOperation>;
 
   /**
-   * Returns the list of all operations (including inherited).
+   * Returns all operations, including inherited ones.
+   *
+   * Derived: the list is assembled from this class and its supertypes, so it is
+   * read-only - mutating methods throw. Modify getEOperations() instead.
    */
-  getEAllOperations(): EOperation[];
+  getEAllOperations(): EList<EOperation>;
 
   /**
    * Returns the structural feature with the given name, or null.

--- a/src/EClassifier.ts
+++ b/src/EClassifier.ts
@@ -9,6 +9,7 @@
 import { ENamedElement } from './ENamedElement.js';
 import { EPackage } from './EPackage.js';
 import { ETypeParameter } from './ETypeParameter.js';
+import { EList } from './EList.js';
 
 /**
  * A representation of the model object 'EClassifier'.
@@ -63,7 +64,7 @@ export interface EClassifier extends ENamedElement {
   /**
    * Returns the list of type parameters.
    */
-  getETypeParameters(): ETypeParameter[];
+  getETypeParameters(): EList<ETypeParameter>;
 
   /**
    * Returns whether the object is an instance of this classifier.

--- a/src/EEnum.ts
+++ b/src/EEnum.ts
@@ -8,6 +8,7 @@
 
 import { EDataType } from './EDataType.js';
 import { EEnumLiteral } from './EEnumLiteral.js';
+import { EList } from './EList.js';
 
 /**
  * A representation of the model object 'EEnum'.
@@ -17,7 +18,7 @@ export interface EEnum extends EDataType {
   /**
    * Returns the list of literals for this enum.
    */
-  getELiterals(): EEnumLiteral[];
+  getELiterals(): EList<EEnumLiteral>;
 
   /**
    * Returns the literal with the given name.

--- a/src/EGenericType.ts
+++ b/src/EGenericType.ts
@@ -9,6 +9,7 @@
 import { EObject } from './EObject.js';
 import { EClassifier } from './EClassifier.js';
 import { ETypeParameter } from './ETypeParameter.js';
+import { EList } from './EList.js';
 
 /**
  * A representation of the model object 'EGeneric Type'.
@@ -28,7 +29,7 @@ export interface EGenericType extends EObject {
   /**
    * Returns the list of type arguments.
    */
-  getETypeArguments(): EGenericType[];
+  getETypeArguments(): EList<EGenericType>;
 
   /**
    * Returns the raw type.

--- a/src/EList.ts
+++ b/src/EList.ts
@@ -1091,6 +1091,134 @@ export function isEList<T>(obj: any): obj is EList<T> {
 }
 
 /**
+ * Returns true for anything that holds a sequence of values - a plain array or
+ * an EList. Use this instead of Array.isArray() wherever a multi-valued feature
+ * value is accepted, since both shapes occur.
+ */
+export function isListValue<T>(value: any): value is T[] | EList<T> {
+  return Array.isArray(value) || isEList<T>(value);
+}
+
+/**
+ * Normalizes a multi-valued feature value to a plain array. Arrays are returned
+ * as-is, ELists are copied out.
+ */
+export function toArray<T>(value: T[] | EList<T>): T[] {
+  return Array.isArray(value) ? value : value.toArray();
+}
+
+/**
+ * A read-only view on a computed list.
+ *
+ * Derived accessors such as getEAllStructuralFeatures() do not own their
+ * contents - they assemble them from the class and its supertypes. Writing into
+ * the result cannot have an effect, so every mutating operation throws instead
+ * of failing silently. This mirrors EcoreEList.UnmodifiableEList in Java EMF,
+ * where the same methods throw UnsupportedOperationException.
+ *
+ * The backing array is used directly rather than copied, so wrapping is cheap.
+ */
+export class UnmodifiableEList<T> extends BasicEList<T> {
+  private readonly accessorName: string;
+
+  /**
+   * @param data the computed contents; used as backing store, not copied
+   * @param accessorName name of the accessor, used in the error message
+   */
+  constructor(data: T[], accessorName: string) {
+    super(null, null);
+    this.data = data;
+    this.accessorName = accessorName;
+  }
+
+  /**
+   * Raises the error every mutating method funnels through.
+   */
+  private refuse(operation: string): never {
+    throw new Error(
+      `Cannot call ${operation}() on the result of ${this.accessorName}: ` +
+      `it is a derived list and cannot be modified. ` +
+      `Modify the owning list instead (e.g. getEStructuralFeatures()).`
+    );
+  }
+
+  override set(_index: number, _element: T): T {
+    this.refuse('set');
+  }
+
+  override add(_element: T): boolean {
+    this.refuse('add');
+  }
+
+  override addAt(_index: number, _element: T): void {
+    this.refuse('addAt');
+  }
+
+  override addAll(_elements: T[]): boolean {
+    this.refuse('addAll');
+  }
+
+  override addAllAt(_index: number, _elements: T[]): boolean {
+    this.refuse('addAllAt');
+  }
+
+  override remove(_element: T): boolean {
+    this.refuse('remove');
+  }
+
+  override removeAt(_index: number): T {
+    this.refuse('removeAt');
+  }
+
+  override clear(): void {
+    this.refuse('clear');
+  }
+
+  override move(_toIndex: number, _fromIndex: number): T {
+    this.refuse('move');
+  }
+
+  override push(..._items: T[]): number {
+    this.refuse('push');
+  }
+
+  override pop(): T | undefined {
+    this.refuse('pop');
+  }
+
+  override shift(): T | undefined {
+    this.refuse('shift');
+  }
+
+  override unshift(..._items: T[]): number {
+    this.refuse('unshift');
+  }
+
+  override splice(_start: number, _deleteCount?: number, ..._items: T[]): T[] {
+    this.refuse('splice');
+  }
+
+  override sort(_compareFn?: (a: T, b: T) => number): this {
+    // Sorting in place would modify the derived result; sort a copy instead.
+    this.refuse('sort');
+  }
+
+  override reverse(): this {
+    this.refuse('reverse');
+  }
+}
+
+/**
+ * Creates a read-only EList over a computed array, with index access.
+ *
+ * @param data the computed contents; used as backing store, not copied
+ * @param accessorName name of the accessor, used in error messages
+ */
+export function createUnmodifiableEList<T>(data: T[], accessorName: string): EList<T> {
+  return createIndexedProxy(new UnmodifiableEList<T>(data, accessorName));
+}
+
+/**
  * Wraps an EList with a Proxy to enable array-like index access (list[0], list[1], etc.)
  *
  * Every EList now installs this Proxy in its own constructor, so this function

--- a/src/EList.ts
+++ b/src/EList.ts
@@ -133,7 +133,7 @@ export interface EList<T> extends Iterable<T> {
   /**
    * Array-compatible filter method.
    */
-  filter(callback: (value: T, index: number, array: T[]) => boolean, thisArg?: any): T[];
+  filter(callback: (value: T, index: number, array: T[]) => unknown, thisArg?: any): T[];
 
   /**
    * Array-compatible map method.
@@ -148,22 +148,22 @@ export interface EList<T> extends Iterable<T> {
   /**
    * Array-compatible find method.
    */
-  find(callback: (value: T, index: number, array: T[]) => boolean, thisArg?: any): T | undefined;
+  find(callback: (value: T, index: number, array: T[]) => unknown, thisArg?: any): T | undefined;
 
   /**
    * Array-compatible findIndex method.
    */
-  findIndex(callback: (value: T, index: number, array: T[]) => boolean, thisArg?: any): number;
+  findIndex(callback: (value: T, index: number, array: T[]) => unknown, thisArg?: any): number;
 
   /**
    * Array-compatible some method.
    */
-  some(callback: (value: T, index: number, array: T[]) => boolean, thisArg?: any): boolean;
+  some(callback: (value: T, index: number, array: T[]) => unknown, thisArg?: any): boolean;
 
   /**
    * Array-compatible every method.
    */
-  every(callback: (value: T, index: number, array: T[]) => boolean, thisArg?: any): boolean;
+  every(callback: (value: T, index: number, array: T[]) => unknown, thisArg?: any): boolean;
 
   /**
    * Array-compatible includes method.
@@ -448,35 +448,35 @@ export class BasicEList<T> implements NotifyingEList<T> {
   /**
    * Array-compatible filter method.
    */
-  filter(callback: (value: T, index: number, array: T[]) => boolean, thisArg?: any): T[] {
+  filter(callback: (value: T, index: number, array: T[]) => unknown, thisArg?: any): T[] {
     return this.data.filter((value, index) => callback.call(thisArg, value, index, this.data));
   }
 
   /**
    * Array-compatible find method.
    */
-  find(callback: (value: T, index: number, array: T[]) => boolean, thisArg?: any): T | undefined {
+  find(callback: (value: T, index: number, array: T[]) => unknown, thisArg?: any): T | undefined {
     return this.data.find((value, index) => callback.call(thisArg, value, index, this.data));
   }
 
   /**
    * Array-compatible findIndex method.
    */
-  findIndex(callback: (value: T, index: number, array: T[]) => boolean, thisArg?: any): number {
+  findIndex(callback: (value: T, index: number, array: T[]) => unknown, thisArg?: any): number {
     return this.data.findIndex((value, index) => callback.call(thisArg, value, index, this.data));
   }
 
   /**
    * Array-compatible some method.
    */
-  some(callback: (value: T, index: number, array: T[]) => boolean, thisArg?: any): boolean {
+  some(callback: (value: T, index: number, array: T[]) => unknown, thisArg?: any): boolean {
     return this.data.some((value, index) => callback.call(thisArg, value, index, this.data));
   }
 
   /**
    * Array-compatible every method.
    */
-  every(callback: (value: T, index: number, array: T[]) => boolean, thisArg?: any): boolean {
+  every(callback: (value: T, index: number, array: T[]) => unknown, thisArg?: any): boolean {
     return this.data.every((value, index) => callback.call(thisArg, value, index, this.data));
   }
 

--- a/src/EList.ts
+++ b/src/EList.ts
@@ -1035,6 +1035,20 @@ export class EObjectContainmentWithInverseEListLazy<T extends EObject = EObject>
     this.inverseSetter(newElement, this.owner);
     super.didSet(index, newElement, oldElement);
   }
+
+  /**
+   * This list holds EClass.eStructuralFeatures, which every derived feature list
+   * is assembled from, so each change has to invalidate those caches.
+   */
+  protected override dispatchNotification(
+    eventType: NotificationEventType,
+    oldValue: any,
+    newValue: any,
+    position: number
+  ): void {
+    bumpMetamodelRevision();
+    super.dispatchNotification(eventType, oldValue, newValue, position);
+  }
 }
 
 /**
@@ -1216,6 +1230,114 @@ export class UnmodifiableEList<T> extends BasicEList<T> {
  */
 export function createUnmodifiableEList<T>(data: T[], accessorName: string): EList<T> {
   return createIndexedProxy(new UnmodifiableEList<T>(data, accessorName));
+}
+
+/**
+ * Counts structural changes to any metamodel element in this runtime.
+ *
+ * Derived lists (getEAllStructuralFeatures() and friends) are assembled from a
+ * class and its supertypes, so a change anywhere up the hierarchy invalidates
+ * them. Java EMF tracks this per class with ESuperAdapter, which maintains a
+ * reverse registry of subclasses and pushes invalidation down. A single global
+ * counter achieves the same correctness with an O(1) check and no bookkeeping:
+ * a cached list is valid exactly while the counter has not moved.
+ *
+ * The trade-off is that a change to one class invalidates every cached list, not
+ * only the affected ones. That matches the typical lifecycle - a model is loaded
+ * and then read many times - and is never worse than recomputing on every call,
+ * which is what happened before.
+ */
+let metamodelRevision = 0;
+
+/**
+ * Records a structural change. Called by the notifying lists below.
+ */
+export function bumpMetamodelRevision(): void {
+  metamodelRevision++;
+}
+
+/**
+ * The current revision, to be stored alongside a cached derived list.
+ */
+export function currentMetamodelRevision(): number {
+  return metamodelRevision;
+}
+
+/**
+ * Holds a derived list together with the revision it was computed at.
+ */
+export interface DerivedListCache<T> {
+  revision: number;
+  list: EList<T>;
+}
+
+/**
+ * Returns the cached derived list, recomputing it when the metamodel changed.
+ *
+ * Keeping the wrapper (not just the array) in the cache also stabilizes object
+ * identity across calls, matching Java EMF where repeated calls to a derived
+ * accessor return the same list while the model is unchanged.
+ *
+ * @param cache holder to read and update; pass a per-object field
+ * @param accessorName name of the accessor, used in error messages
+ * @param compute builds the contents; only called when the cache is stale
+ */
+export function cachedDerivedList<T>(
+  cache: { value: DerivedListCache<T> | null },
+  accessorName: string,
+  compute: () => T[]
+): EList<T> {
+  const revision = currentMetamodelRevision();
+  if (cache.value !== null && cache.value.revision === revision) {
+    return cache.value.list;
+  }
+  const list = createUnmodifiableEList(compute(), accessorName);
+  cache.value = { revision, list };
+  return list;
+}
+
+/**
+ * A BasicEList that records a structural change on every mutation, so cached
+ * derived lists notice. Every mutation funnels through dispatchNotification,
+ * which is why overriding it alone is sufficient.
+ *
+ * The feature is resolved lazily: metamodel lists exist before the Ecore
+ * package that describes them has finished bootstrapping.
+ */
+export class MetamodelEList<T> extends BasicEList<T> {
+  private featureResolver: (() => EStructuralFeature | null) | null;
+
+  constructor(owner: EObject | null, featureResolver?: () => EStructuralFeature | null) {
+    super(owner, null);
+    this.featureResolver = featureResolver ?? null;
+  }
+
+  override getFeature(): EStructuralFeature | null {
+    if (this.feature === null && this.featureResolver !== null) {
+      this.feature = this.featureResolver();
+    }
+    return this.feature;
+  }
+
+  protected override dispatchNotification(
+    eventType: NotificationEventType,
+    oldValue: any,
+    newValue: any,
+    position: number
+  ): void {
+    bumpMetamodelRevision();
+    super.dispatchNotification(eventType, oldValue, newValue, position);
+  }
+}
+
+/**
+ * Creates a MetamodelEList with index access.
+ */
+export function createMetamodelEList<T>(
+  owner: EObject | null,
+  featureResolver?: () => EStructuralFeature | null
+): EList<T> {
+  return createIndexedProxy(new MetamodelEList<T>(owner, featureResolver));
 }
 
 /**

--- a/src/EList.ts
+++ b/src/EList.ts
@@ -1122,6 +1122,39 @@ export function toArray<T>(value: T[] | EList<T>): T[] {
 }
 
 /**
+ * Replaces the contents of an owned list with the given value.
+ *
+ * Used by eSet() for multi-valued features: the list itself must be kept, since
+ * it manages containment and notifications, so its contents are replaced rather
+ * than the field being reassigned. Accepts an array, another EList, or any
+ * iterable except a string.
+ *
+ * @returns true if the value was a sequence and the list was updated
+ */
+export function replaceListContents<T>(list: EList<T>, value: unknown): boolean {
+  let items: T[];
+  if (Array.isArray(value)) {
+    items = value as T[];
+  } else if (isEList<T>(value)) {
+    items = value.toArray();
+  } else if (
+    value !== null &&
+    typeof value === 'object' &&
+    typeof (value as any)[Symbol.iterator] === 'function'
+  ) {
+    items = [...(value as Iterable<T>)];
+  } else {
+    return false;
+  }
+
+  // Copy first: the value may be the list itself, or a view onto it.
+  const snapshot = [...items];
+  list.clear();
+  list.addAll(snapshot);
+  return true;
+}
+
+/**
  * A read-only view on a computed list.
  *
  * Derived accessors such as getEAllStructuralFeatures() do not own their

--- a/src/EMap.ts
+++ b/src/EMap.ts
@@ -237,7 +237,7 @@ export class BasicEMap<K, V> implements EMap<K, V> {
   [Symbol.iterator](): Iterator<EObject> { return this.delegateList[Symbol.iterator](); }
 
   push(...items: EObject[]): number { return this.delegateList.push(...items); }
-  filter(callback: (value: EObject, index: number, array: EObject[]) => boolean, thisArg?: any): EObject[] {
+  filter(callback: (value: EObject, index: number, array: EObject[]) => unknown, thisArg?: any): EObject[] {
     return this.delegateList.filter(callback, thisArg);
   }
   map<U>(callback: (value: EObject, index: number, array: EObject[]) => U, thisArg?: any): U[] {
@@ -246,16 +246,16 @@ export class BasicEMap<K, V> implements EMap<K, V> {
   forEach(callback: (value: EObject, index: number, array: EObject[]) => void, thisArg?: any): void {
     this.delegateList.forEach(callback, thisArg);
   }
-  find(callback: (value: EObject, index: number, array: EObject[]) => boolean, thisArg?: any): EObject | undefined {
+  find(callback: (value: EObject, index: number, array: EObject[]) => unknown, thisArg?: any): EObject | undefined {
     return this.delegateList.find(callback, thisArg);
   }
-  findIndex(callback: (value: EObject, index: number, array: EObject[]) => boolean, thisArg?: any): number {
+  findIndex(callback: (value: EObject, index: number, array: EObject[]) => unknown, thisArg?: any): number {
     return this.delegateList.findIndex(callback, thisArg);
   }
-  some(callback: (value: EObject, index: number, array: EObject[]) => boolean, thisArg?: any): boolean {
+  some(callback: (value: EObject, index: number, array: EObject[]) => unknown, thisArg?: any): boolean {
     return this.delegateList.some(callback, thisArg);
   }
-  every(callback: (value: EObject, index: number, array: EObject[]) => boolean, thisArg?: any): boolean {
+  every(callback: (value: EObject, index: number, array: EObject[]) => unknown, thisArg?: any): boolean {
     return this.delegateList.every(callback, thisArg);
   }
   includes(element: EObject): boolean { return this.delegateList.includes(element); }

--- a/src/EModelElement.ts
+++ b/src/EModelElement.ts
@@ -8,6 +8,7 @@
 
 import { EObject } from './EObject.js';
 import { EAnnotation } from './EAnnotation.js';
+import { EList } from './EList.js';
 
 /**
  * A representation of the model object 'EModel Element'.
@@ -18,7 +19,7 @@ export interface EModelElement extends EObject {
    * Returns the list of annotations.
    * It represents additional associated information.
    */
-  getEAnnotations(): EAnnotation[];
+  getEAnnotations(): EList<EAnnotation>;
 
   /**
    * Return the annotation with a matching source attribute.

--- a/src/EOperation.ts
+++ b/src/EOperation.ts
@@ -10,6 +10,7 @@ import { ENamedElement } from './ENamedElement.js';
 import { EClass } from './EClass.js';
 import { EClassifier } from './EClassifier.js';
 import { EParameter } from './EParameter.js';
+import { EList } from './EList.js';
 
 /**
  * A representation of the model object 'EOperation'.
@@ -34,12 +35,12 @@ export interface EOperation extends ENamedElement {
   /**
    * Returns the list of parameters.
    */
-  getEParameters(): EParameter[];
+  getEParameters(): EList<EParameter>;
 
   /**
    * Returns the list of exceptions that this operation can throw.
    */
-  getEExceptions(): EClassifier[];
+  getEExceptions(): EList<EClassifier>;
 
   /**
    * Returns whether the operation is many-valued.

--- a/src/EReference.ts
+++ b/src/EReference.ts
@@ -9,6 +9,7 @@
 import { EStructuralFeature } from './EStructuralFeature.js';
 import { EClass } from './EClass.js';
 import { EAttribute } from './EAttribute.js';
+import { EList } from './EList.js';
 
 /**
  * A representation of the model object 'EReference'.
@@ -62,5 +63,5 @@ export interface EReference extends EStructuralFeature {
   /**
    * Returns the keys for map-like references.
    */
-  getEKeys(): EAttribute[];
+  getEKeys(): EList<EAttribute>;
 }

--- a/src/ETypeParameter.ts
+++ b/src/ETypeParameter.ts
@@ -8,6 +8,7 @@
 
 import { ENamedElement } from './ENamedElement.js';
 import { EGenericType } from './EGenericType.js';
+import { EList } from './EList.js';
 
 /**
  * A representation of the model object 'EType Parameter'.
@@ -17,5 +18,5 @@ export interface ETypeParameter extends ENamedElement {
   /**
    * Returns the list of bounds for this type parameter.
    */
-  getEBounds(): EGenericType[];
+  getEBounds(): EList<EGenericType>;
 }

--- a/src/ResourceSet.ts
+++ b/src/ResourceSet.ts
@@ -10,6 +10,7 @@ import { Resource } from './Resource.js';
 import { URI } from './URI.js';
 import { EObject } from './EObject.js';
 import { EPackageRegistry } from './EPackage.js';
+import { EList } from './EList.js';
 
 /**
  * A collection of related persistent documents.
@@ -18,7 +19,7 @@ export interface ResourceSet {
   /**
    * Returns the list of resources.
    */
-  getResources(): Resource[];
+  getResources(): EList<Resource>;
 
   /**
    * Returns the resource with the given URI, loading it if necessary.

--- a/src/runtime/BasicEAnnotation.ts
+++ b/src/runtime/BasicEAnnotation.ts
@@ -15,6 +15,7 @@ import { EStructuralFeature } from '../EStructuralFeature.js';
 import { BasicEObject } from './BasicEObject.js';
 import { ecoreRegistry } from '../ecore/EcoreRegistry.js';
 import { EMap, createEMap } from '../EMap.js';
+import { EList, createMetamodelEList, replaceListContents } from '../EList.js';
 
 /**
  * Basic EAnnotation implementation
@@ -23,8 +24,8 @@ export class BasicEAnnotation extends BasicEObject implements EAnnotation {
   private source: string | null = null;
   private _detailsMap: EMap<string, string> | null = null;
   private eModelElement: EModelElement | null = null;
-  private contents: EObject[] = [];
-  private references: EObject[] = [];
+  private contents: EList<EObject> = createMetamodelEList<EObject>(this);
+  private references: EList<EObject> = createMetamodelEList<EObject>(this);
 
   private getOrCreateDetailsMap(): EMap<string, string> {
     if (!this._detailsMap) {
@@ -56,21 +57,23 @@ export class BasicEAnnotation extends BasicEObject implements EAnnotation {
     this.eModelElement = value;
   }
 
-  getContents(): EObject[] {
+  getContents(): EList<EObject> {
     return this.contents;
   }
 
-  getReferences(): EObject[] {
+  getReferences(): EList<EObject> {
     return this.references;
   }
 
   // EModelElement methods
-  getEAnnotations(): EAnnotation[] {
-    return [];
+  private eAnnotations: EList<EAnnotation> = createMetamodelEList<EAnnotation>(this);
+
+  getEAnnotations(): EList<EAnnotation> {
+    return this.eAnnotations;
   }
 
   getEAnnotation(source: string): EAnnotation | null {
-    return null;
+    return this.eAnnotations.find(a => a.getSource() === source) || null;
   }
 
   override eClass(): EClass {
@@ -117,16 +120,10 @@ export class BasicEAnnotation extends BasicEObject implements EAnnotation {
         super.eSet(feature, newValue);
         break;
       case 'contents':
-        if (Array.isArray(newValue)) {
-          this.contents = newValue;
-        }
-        super.eSet(feature, newValue);
+        replaceListContents(this.contents, newValue);
         break;
       case 'references':
-        if (Array.isArray(newValue)) {
-          this.references = newValue;
-        }
-        super.eSet(feature, newValue);
+        replaceListContents(this.references, newValue);
         break;
       default:
         super.eSet(feature, newValue);

--- a/src/runtime/BasicEClass.ts
+++ b/src/runtime/BasicEClass.ts
@@ -15,7 +15,15 @@ import { EPackage } from '../EPackage.js';
 import { BasicEObject } from './BasicEObject.js';
 import { EAnnotation } from '../EAnnotation.js';
 import { ecoreRegistry } from '../ecore/EcoreRegistry.js';
-import { EList, EObjectContainmentWithInverseEListLazy, createIndexedProxy } from '../EList.js';
+import {
+  EList,
+  EObjectContainmentWithInverseEListLazy,
+  createIndexedProxy,
+  createMetamodelEList,
+  cachedDerivedList,
+  DerivedListCache,
+  replaceListContents,
+} from '../EList.js';
 import { ETypeParameter } from '../ETypeParameter.js';
 import { EGenericType } from '../EGenericType.js';
 import { EObject } from '../EObject.js';
@@ -27,9 +35,9 @@ export class BasicEClass extends BasicEObject implements EClass {
   private _name: string | null = null;
   private abstract_: boolean = false;
   private interface_: boolean = false;
-  private eSuperTypes: EClass[] = [];
+  private _eSuperTypes: EList<EClass> | null = null;
   private _eStructuralFeatures: EList<EStructuralFeature> | null = null;
-  private eOperations: EOperation[] = [];
+  private _eOperations: EList<EOperation> | null = null;
   private ePackage: EPackage | null = null;
   private instanceClassName: string | null = null;
   private instanceClass: Function | null = null;
@@ -38,6 +46,19 @@ export class BasicEClass extends BasicEObject implements EClass {
   private eGenericSuperTypes: EGenericType[] = [];
   private eAnnotations: EAnnotation[] = [];
   private xmlNameToFeature: Map<string, EStructuralFeature> = new Map();
+
+  /**
+   * Caches for the derived lists, each invalidated by the global metamodel
+   * revision. See cachedDerivedList().
+   */
+  private allSuperTypesCache: { value: DerivedListCache<EClass> | null } = { value: null };
+  private allFeaturesCache: { value: DerivedListCache<EStructuralFeature> | null } = { value: null };
+  private attributesCache: { value: DerivedListCache<EAttribute> | null } = { value: null };
+  private allAttributesCache: { value: DerivedListCache<EAttribute> | null } = { value: null };
+  private referencesCache: { value: DerivedListCache<EReference> | null } = { value: null };
+  private allReferencesCache: { value: DerivedListCache<EReference> | null } = { value: null };
+  private allContainmentsCache: { value: DerivedListCache<EReference> | null } = { value: null };
+  private allOperationsCache: { value: DerivedListCache<EOperation> | null } = { value: null };
 
   // Public getter for PrimeVue compatibility (optionLabel="name")
   get name(): string | null {
@@ -68,26 +89,31 @@ export class BasicEClass extends BasicEObject implements EClass {
     this.interface_ = value;
   }
 
-  getESuperTypes(): EClass[] {
-    return this.eSuperTypes;
+  getESuperTypes(): EList<EClass> {
+    if (this._eSuperTypes === null) {
+      this._eSuperTypes = createMetamodelEList<EClass>(this, () => this.resolveOwnFeature('eSuperTypes'));
+    }
+    return this._eSuperTypes;
   }
 
-  getEAllSuperTypes(): EClass[] {
-    const all: EClass[] = [];
-    const visited = new Set<EClass>();
+  getEAllSuperTypes(): EList<EClass> {
+    return cachedDerivedList(this.allSuperTypesCache, 'getEAllSuperTypes', () => {
+      const all: EClass[] = [];
+      const visited = new Set<EClass>();
 
-    const collect = (eClass: EClass) => {
-      for (const superType of eClass.getESuperTypes()) {
-        if (!visited.has(superType)) {
-          visited.add(superType);
-          collect(superType);
-          all.push(superType);
+      const collect = (eClass: EClass) => {
+        for (const superType of eClass.getESuperTypes()) {
+          if (!visited.has(superType)) {
+            visited.add(superType);
+            collect(superType);
+            all.push(superType);
+          }
         }
-      }
-    };
+      };
 
-    collect(this);
-    return all;
+      collect(this);
+      return all;
+    });
   }
 
   getEIDAttribute(): EAttribute | null {
@@ -138,52 +164,91 @@ export class BasicEClass extends BasicEObject implements EClass {
     return this._eStructuralFeatures!;
   }
 
-  getEAllStructuralFeatures(): EStructuralFeature[] {
-    const all: EStructuralFeature[] = [];
+  getEAllStructuralFeatures(): EList<EStructuralFeature> {
+    return cachedDerivedList(this.allFeaturesCache, 'getEAllStructuralFeatures', () => {
+      const all: EStructuralFeature[] = [];
 
-    // Inherited features first (EMF standard ordering)
-    for (const superType of this.getEAllSuperTypes()) {
-      all.push(...superType.getEStructuralFeatures());
+      // Inherited features first (EMF standard ordering)
+      for (const superType of this.getEAllSuperTypes()) {
+        all.push(...superType.getEStructuralFeatures());
+      }
+
+      // Then own features
+      all.push(...this.getEStructuralFeatures());
+
+      return all;
+    });
+  }
+
+  getEAttributes(): EList<EAttribute> {
+    return cachedDerivedList(this.attributesCache, 'getEAttributes', () =>
+      this.getEStructuralFeatures().filter(f => this.isAttribute(f)) as EAttribute[]
+    );
+  }
+
+  getEAllAttributes(): EList<EAttribute> {
+    return cachedDerivedList(this.allAttributesCache, 'getEAllAttributes', () =>
+      this.getEAllStructuralFeatures().filter(f => this.isAttribute(f)) as EAttribute[]
+    );
+  }
+
+  getEReferences(): EList<EReference> {
+    return cachedDerivedList(this.referencesCache, 'getEReferences', () =>
+      this.getEStructuralFeatures().filter(f => this.isReference(f)) as EReference[]
+    );
+  }
+
+  getEAllReferences(): EList<EReference> {
+    return cachedDerivedList(this.allReferencesCache, 'getEAllReferences', () =>
+      this.getEAllStructuralFeatures().filter(f => this.isReference(f)) as EReference[]
+    );
+  }
+
+  getEAllContainments(): EList<EReference> {
+    return cachedDerivedList(this.allContainmentsCache, 'getEAllContainments', () =>
+      this.getEAllReferences().filter(ref => ref.isContainment())
+    );
+  }
+
+  getEOperations(): EList<EOperation> {
+    if (this._eOperations === null) {
+      this._eOperations = createMetamodelEList<EOperation>(this, () => this.resolveOwnFeature('eOperations'));
     }
-
-    // Then own features
-    all.push(...this.getEStructuralFeatures());
-
-    return all;
+    return this._eOperations;
   }
 
-  getEAttributes(): EAttribute[] {
-    return this.getEStructuralFeatures().filter(f => this.isAttribute(f)) as EAttribute[];
+  getEAllOperations(): EList<EOperation> {
+    return cachedDerivedList(this.allOperationsCache, 'getEAllOperations', () => {
+      const all: EOperation[] = [...this.getEOperations()];
+
+      for (const superType of this.getEAllSuperTypes()) {
+        all.push(...superType.getEOperations());
+      }
+
+      return all;
+    });
   }
 
-  getEAllAttributes(): EAttribute[] {
-    return this.getEAllStructuralFeatures().filter(f => this.isAttribute(f)) as EAttribute[];
-  }
-
-  getEReferences(): EReference[] {
-    return this.getEStructuralFeatures().filter(f => this.isReference(f)) as EReference[];
-  }
-
-  getEAllReferences(): EReference[] {
-    return this.getEAllStructuralFeatures().filter(f => this.isReference(f)) as EReference[];
-  }
-
-  getEAllContainments(): EReference[] {
-    return this.getEAllReferences().filter(ref => ref.isContainment());
-  }
-
-  getEOperations(): EOperation[] {
-    return this.eOperations;
-  }
-
-  getEAllOperations(): EOperation[] {
-    const all: EOperation[] = [...this.eOperations];
-
-    for (const superType of this.getEAllSuperTypes()) {
-      all.push(...superType.getEOperations());
+  /**
+   * Resolves one of this class's own metamodel features (eSuperTypes,
+   * eOperations, ...) on the Ecore EClass descriptor, for notifications.
+   *
+   * Returns null while the Ecore package is still bootstrapping, which is why
+   * the lists resolve their feature lazily rather than in the constructor.
+   */
+  private resolveOwnFeature(name: string): EStructuralFeature | null {
+    if (!ecoreRegistry.isRegistered()) {
+      return null;
     }
-
-    return all;
+    try {
+      const eClassClass = ecoreRegistry.getEClassClass();
+      if (eClassClass !== this && eClassClass instanceof BasicEClass && eClassClass._eStructuralFeatures !== null) {
+        return eClassClass.getEStructuralFeature(name);
+      }
+    } catch {
+      // Ignore during bootstrap
+    }
+    return null;
   }
 
   getEStructuralFeature(featureNameOrID: string | number): EStructuralFeature | null {
@@ -318,14 +383,14 @@ export class BasicEClass extends BasicEObject implements EClass {
    * Add operation to this class
    */
   addOperation(operation: EOperation): void {
-    this.eOperations.push(operation);
+    this.getEOperations().add(operation);
   }
 
   /**
    * Add super type
    */
   addSuperType(superType: EClass): void {
-    this.eSuperTypes.push(superType);
+    this.getESuperTypes().add(superType);
   }
 
   // EObject methods
@@ -354,11 +419,11 @@ export class BasicEClass extends BasicEObject implements EClass {
       case 'interface':
         return this.interface_;
       case 'eSuperTypes':
-        return this.eSuperTypes;
+        return this.getESuperTypes();
       case 'eStructuralFeatures':
         return this.getEStructuralFeatures();
       case 'eOperations':
-        return this.eOperations;
+        return this.getEOperations();
       case 'eTypeParameters':
         return this.eTypeParameters;
       case 'eGenericSuperTypes':
@@ -391,27 +456,14 @@ export class BasicEClass extends BasicEObject implements EClass {
         super.eSet(feature, newValue);
         break;
       case 'eSuperTypes':
-        if (Array.isArray(newValue)) {
-          this.eSuperTypes = newValue;
-        }
-        super.eSet(feature, newValue);
+        replaceListContents(this.getESuperTypes(), newValue);
         break;
       case 'eStructuralFeatures':
-        // Clear and re-add all features through the EList
-        // EList handles its own notifications, so don't call super.eSet
-        const featureList = this.getEStructuralFeatures();
-        featureList.clear();
-        if (Array.isArray(newValue)) {
-          featureList.addAll(newValue);
-        } else if (newValue && typeof newValue[Symbol.iterator] === 'function') {
-          featureList.addAll([...newValue]);
-        }
+        // The EList sends its own notifications, so super.eSet is not called.
+        replaceListContents(this.getEStructuralFeatures(), newValue);
         break;
       case 'eOperations':
-        if (Array.isArray(newValue)) {
-          this.eOperations = newValue;
-        }
-        super.eSet(feature, newValue);
+        replaceListContents(this.getEOperations(), newValue);
         break;
       case 'eTypeParameters':
         if (Array.isArray(newValue)) {

--- a/src/runtime/BasicEClass.ts
+++ b/src/runtime/BasicEClass.ts
@@ -15,18 +15,10 @@ import { EPackage } from '../EPackage.js';
 import { BasicEObject } from './BasicEObject.js';
 import { EAnnotation } from '../EAnnotation.js';
 import { ecoreRegistry } from '../ecore/EcoreRegistry.js';
-import {
-  EList,
-  EObjectContainmentWithInverseEListLazy,
-  createIndexedProxy,
-  createMetamodelEList,
-  cachedDerivedList,
-  DerivedListCache,
-  replaceListContents,
-} from '../EList.js';
 import { ETypeParameter } from '../ETypeParameter.js';
 import { EGenericType } from '../EGenericType.js';
 import { EObject } from '../EObject.js';
+import { DerivedListCache, EList, EObjectContainmentWithInverseEListLazy, cachedDerivedList, createIndexedProxy, createMetamodelEList, replaceListContents } from '../EList.js';
 
 /**
  * Basic EClass implementation
@@ -42,9 +34,9 @@ export class BasicEClass extends BasicEObject implements EClass {
   private instanceClassName: string | null = null;
   private instanceClass: Function | null = null;
   private featureID: number = 0;
-  private eTypeParameters: ETypeParameter[] = [];
-  private eGenericSuperTypes: EGenericType[] = [];
-  private eAnnotations: EAnnotation[] = [];
+  private eTypeParameters: EList<ETypeParameter> = createMetamodelEList<ETypeParameter>(this);
+  private eGenericSuperTypes: EList<EGenericType> = createMetamodelEList<EGenericType>(this);
+  private eAnnotations: EList<EAnnotation> = createMetamodelEList<EAnnotation>(this);
   private xmlNameToFeature: Map<string, EStructuralFeature> = new Map();
 
   /**
@@ -341,7 +333,7 @@ export class BasicEClass extends BasicEObject implements EClass {
     this.ePackage = pkg;
   }
 
-  getETypeParameters(): ETypeParameter[] {
+  getETypeParameters(): EList<ETypeParameter> {
     return this.eTypeParameters;
   }
 
@@ -394,7 +386,7 @@ export class BasicEClass extends BasicEObject implements EClass {
   }
 
   // EObject methods
-  getEAnnotations(): EAnnotation[] {
+  getEAnnotations(): EList<EAnnotation> {
     return this.eAnnotations;
   }
 
@@ -466,22 +458,13 @@ export class BasicEClass extends BasicEObject implements EClass {
         replaceListContents(this.getEOperations(), newValue);
         break;
       case 'eTypeParameters':
-        if (Array.isArray(newValue)) {
-          this.eTypeParameters = newValue;
-        }
-        super.eSet(feature, newValue);
+        replaceListContents(this.eTypeParameters, newValue);
         break;
       case 'eGenericSuperTypes':
-        if (Array.isArray(newValue)) {
-          this.eGenericSuperTypes = newValue;
-        }
-        super.eSet(feature, newValue);
+        replaceListContents(this.eGenericSuperTypes, newValue);
         break;
       case 'eAnnotations':
-        if (Array.isArray(newValue)) {
-          this.eAnnotations = newValue;
-        }
-        super.eSet(feature, newValue);
+        replaceListContents(this.eAnnotations, newValue);
         break;
       case 'instanceClassName':
         this.instanceClassName = newValue;

--- a/src/runtime/BasicEDataType.ts
+++ b/src/runtime/BasicEDataType.ts
@@ -14,6 +14,7 @@ import { EAnnotation } from '../EAnnotation.js';
 import { EStructuralFeature } from '../EStructuralFeature.js';
 import { ETypeParameter } from '../ETypeParameter.js';
 import { ecoreRegistry } from '../ecore/EcoreRegistry.js';
+import { EList, createMetamodelEList, replaceListContents } from '../EList.js';
 
 /**
  * Basic EDataType implementation
@@ -24,8 +25,8 @@ export class BasicEDataType extends BasicEObject implements EDataType {
   private instanceClass: Function | null = null;
   private ePackage: EPackage | null = null;
   private serializable: boolean = true;
-  private eAnnotations: EAnnotation[] = [];
-  private eTypeParameters: ETypeParameter[] = [];
+  private eAnnotations: EList<EAnnotation> = createMetamodelEList<EAnnotation>(this);
+  private eTypeParameters: EList<ETypeParameter> = createMetamodelEList<ETypeParameter>(this);
 
   getName(): string | null {
     return this.name;
@@ -94,7 +95,7 @@ export class BasicEDataType extends BasicEObject implements EDataType {
     this.ePackage = pkg;
   }
 
-  getETypeParameters(): ETypeParameter[] {
+  getETypeParameters(): EList<ETypeParameter> {
     return this.eTypeParameters;
   }
 
@@ -139,7 +140,7 @@ export class BasicEDataType extends BasicEObject implements EDataType {
   }
 
   // EObject methods
-  getEAnnotations(): EAnnotation[] {
+  getEAnnotations(): EList<EAnnotation> {
     return this.eAnnotations;
   }
 
@@ -191,16 +192,10 @@ export class BasicEDataType extends BasicEObject implements EDataType {
         super.eSet(feature, newValue);
         break;
       case 'eAnnotations':
-        if (Array.isArray(newValue)) {
-          this.eAnnotations = newValue;
-        }
-        super.eSet(feature, newValue);
+        replaceListContents(this.eAnnotations, newValue);
         break;
       case 'eTypeParameters':
-        if (Array.isArray(newValue)) {
-          this.eTypeParameters = newValue;
-        }
-        super.eSet(feature, newValue);
+        replaceListContents(this.eTypeParameters, newValue);
         break;
       default:
         super.eSet(feature, newValue);

--- a/src/runtime/BasicEEnum.ts
+++ b/src/runtime/BasicEEnum.ts
@@ -13,14 +13,15 @@ import { EStructuralFeature } from '../EStructuralFeature.js';
 import { BasicEDataType } from './BasicEDataType.js';
 import { BasicEEnumLiteral } from './BasicEEnumLiteral.js';
 import { ecoreRegistry } from '../ecore/EcoreRegistry.js';
+import { EList, createMetamodelEList, replaceListContents } from '../EList.js';
 
 /**
  * Basic EEnum implementation
  */
 export class BasicEEnum extends BasicEDataType implements EEnum {
-  private eLiterals: BasicEEnumLiteral[] = [];
+  private eLiterals: EList<BasicEEnumLiteral> = createMetamodelEList<BasicEEnumLiteral>(this);
 
-  getELiterals(): EEnumLiteral[] {
+  getELiterals(): EList<EEnumLiteral> {
     return this.eLiterals;
   }
 
@@ -68,8 +69,7 @@ export class BasicEEnum extends BasicEDataType implements EEnum {
     const featureName = feature.getName();
     switch (featureName) {
       case 'eLiterals':
-        if (Array.isArray(newValue)) {
-          this.eLiterals = newValue;
+        if (replaceListContents(this.eLiterals, newValue)) {
           for (const lit of this.eLiterals) {
             if (lit instanceof BasicEEnumLiteral) {
               lit.setEEnum(this);

--- a/src/runtime/BasicEEnumLiteral.ts
+++ b/src/runtime/BasicEEnumLiteral.ts
@@ -13,6 +13,7 @@ import { EClass } from '../EClass.js';
 import { EStructuralFeature } from '../EStructuralFeature.js';
 import { BasicEObject } from './BasicEObject.js';
 import { ecoreRegistry } from '../ecore/EcoreRegistry.js';
+import { EList, createMetamodelEList, replaceListContents } from '../EList.js';
 
 /**
  * Basic EEnumLiteral implementation
@@ -23,7 +24,7 @@ export class BasicEEnumLiteral extends BasicEObject implements EEnumLiteral {
   private instance: any = null;
   private literal: string | null = null;
   private eEnum: EEnum | null = null;
-  private eAnnotations: EAnnotation[] = [];
+  private eAnnotations: EList<EAnnotation> = createMetamodelEList<EAnnotation>(this);
 
   getName(): string | null {
     return this._name;
@@ -71,7 +72,7 @@ export class BasicEEnumLiteral extends BasicEObject implements EEnumLiteral {
   }
 
   // EModelElement methods
-  getEAnnotations(): EAnnotation[] {
+  getEAnnotations(): EList<EAnnotation> {
     return this.eAnnotations;
   }
 
@@ -127,10 +128,7 @@ export class BasicEEnumLiteral extends BasicEObject implements EEnumLiteral {
         super.eSet(feature, newValue);
         break;
       case 'eAnnotations':
-        if (Array.isArray(newValue)) {
-          this.eAnnotations = newValue;
-        }
-        super.eSet(feature, newValue);
+        replaceListContents(this.eAnnotations, newValue);
         break;
       default:
         super.eSet(feature, newValue);

--- a/src/runtime/BasicEFactory.ts
+++ b/src/runtime/BasicEFactory.ts
@@ -14,6 +14,8 @@ import { EDataType } from '../EDataType.js';
 import { DynamicEObject } from './BasicEObject.js';
 import { ecoreRegistry } from '../ecore/EcoreRegistry.js';
 import { dataTypeRegistry } from './DataTypeRegistry.js';
+import { EList, createMetamodelEList } from '../EList.js';
+import { EAnnotation } from '../EAnnotation.js';
 
 /**
  * Basic EFactory implementation
@@ -86,8 +88,10 @@ export class BasicEFactory implements EFactory {
   }
 
   // EModelElement methods
-  getEAnnotations(): any[] {
-    return [];
+  private eAnnotations: EList<EAnnotation> = createMetamodelEList<EAnnotation>(this);
+
+  getEAnnotations(): EList<EAnnotation> {
+    return this.eAnnotations;
   }
 
   getEAnnotation(source: string): any {

--- a/src/runtime/BasicEGenericType.ts
+++ b/src/runtime/BasicEGenericType.ts
@@ -13,6 +13,7 @@ import { EClassifier } from '../EClassifier.js';
 import { EStructuralFeature } from '../EStructuralFeature.js';
 import { BasicEObject } from './BasicEObject.js';
 import { ecoreRegistry } from '../ecore/EcoreRegistry.js';
+import { EList, createMetamodelEList, replaceListContents } from '../EList.js';
 
 /**
  * Basic EGenericType implementation (#65).
@@ -24,7 +25,7 @@ import { ecoreRegistry } from '../ecore/EcoreRegistry.js';
 export class BasicEGenericType extends BasicEObject implements EGenericType {
   private eClassifier: EClassifier | null = null;
   private eTypeParameter: ETypeParameter | null = null;
-  private eTypeArguments: EGenericType[] = [];
+  private eTypeArguments: EList<EGenericType> = createMetamodelEList<EGenericType>(this);
   private eUpperBound: EGenericType | null = null;
   private eLowerBound: EGenericType | null = null;
 
@@ -44,7 +45,7 @@ export class BasicEGenericType extends BasicEObject implements EGenericType {
     this.eTypeParameter = value;
   }
 
-  getETypeArguments(): EGenericType[] {
+  getETypeArguments(): EList<EGenericType> {
     return this.eTypeArguments;
   }
 
@@ -115,9 +116,7 @@ export class BasicEGenericType extends BasicEObject implements EGenericType {
         this.eTypeParameter = newValue;
         break;
       case 'eTypeArguments':
-        if (Array.isArray(newValue)) {
-          this.eTypeArguments = newValue;
-        }
+        replaceListContents(this.eTypeArguments, newValue);
         break;
       case 'eUpperBound':
         this.eUpperBound = newValue;

--- a/src/runtime/BasicEObject.ts
+++ b/src/runtime/BasicEObject.ts
@@ -17,7 +17,7 @@ import { InternalEObject, isInternalEObject } from '../InternalEObject.js';
 import { Adapter, isAdapterInternal } from '../notify/Adapter.js';
 import { Notification, NotificationImpl, NotificationType } from '../notify/Notification.js';
 import { Notifier } from '../notify/Notifier.js';
-import { EList, BasicEList, EObjectContainmentEList, EObjectEList, isEList, createContainmentEList, createEObjectEList, createBasicEList } from '../EList.js';
+import { BasicEList, EList, EObjectContainmentEList, EObjectEList, createBasicEList, createContainmentEList, createEObjectEList, isEList } from '../EList.js';
 
 /**
  * Minimal EObject implementation

--- a/src/runtime/BasicEOperation.ts
+++ b/src/runtime/BasicEOperation.ts
@@ -16,6 +16,7 @@ import { ETypeParameter } from '../ETypeParameter.js';
 import { BasicEObject } from './BasicEObject.js';
 import { EAnnotation } from '../EAnnotation.js';
 import { ecoreRegistry } from '../ecore/EcoreRegistry.js';
+import { EList, createMetamodelEList, replaceListContents } from '../EList.js';
 
 /**
  * Basic EOperation implementation
@@ -24,11 +25,11 @@ export class BasicEOperation extends BasicEObject implements EOperation {
   private name: string | null = null;
   private eContainingClass: EClass | null = null;
   private eType: EClassifier | null = null;
-  private eParameters: EParameter[] = [];
-  private eExceptions: EClassifier[] = [];
-  private eAnnotations: EAnnotation[] = [];
+  private eParameters: EList<EParameter> = createMetamodelEList<EParameter>(this);
+  private eExceptions: EList<EClassifier> = createMetamodelEList<EClassifier>(this);
+  private eAnnotations: EList<EAnnotation> = createMetamodelEList<EAnnotation>(this);
   private eGenericType: EGenericType | null = null;
-  private eTypeParameters: ETypeParameter[] = [];
+  private eTypeParameters: EList<ETypeParameter> = createMetamodelEList<ETypeParameter>(this);
   private ordered: boolean = true;
   private unique: boolean = true;
   private lowerBound: number = 0;
@@ -66,7 +67,7 @@ export class BasicEOperation extends BasicEObject implements EOperation {
     this.eGenericType = value;
   }
 
-  getETypeParameters(): ETypeParameter[] {
+  getETypeParameters(): EList<ETypeParameter> {
     return this.eTypeParameters;
   }
 
@@ -74,20 +75,20 @@ export class BasicEOperation extends BasicEObject implements EOperation {
     this.eType = value;
   }
 
-  getEParameters(): EParameter[] {
+  getEParameters(): EList<EParameter> {
     return this.eParameters;
   }
 
   addParameter(parameter: EParameter): void {
-    this.eParameters.push(parameter);
+    this.eParameters.add(parameter);
   }
 
-  getEExceptions(): EClassifier[] {
+  getEExceptions(): EList<EClassifier> {
     return this.eExceptions;
   }
 
   addException(exception: EClassifier): void {
-    this.eExceptions.push(exception);
+    this.eExceptions.add(exception);
   }
 
   isMany(): boolean {
@@ -165,7 +166,7 @@ export class BasicEOperation extends BasicEObject implements EOperation {
   }
 
   // EObject methods
-  getEAnnotations(): EAnnotation[] {
+  getEAnnotations(): EList<EAnnotation> {
     return this.eAnnotations;
   }
 
@@ -222,24 +223,16 @@ export class BasicEOperation extends BasicEObject implements EOperation {
         this.eGenericType = newValue;
         break;
       case 'eTypeParameters':
-        if (Array.isArray(newValue)) {
-          this.eTypeParameters = newValue;
-        }
+        replaceListContents(this.eTypeParameters, newValue);
         break;
       case 'eParameters':
-        if (Array.isArray(newValue)) {
-          this.eParameters = newValue;
-        }
+        replaceListContents(this.eParameters, newValue);
         break;
       case 'eExceptions':
-        if (Array.isArray(newValue)) {
-          this.eExceptions = newValue;
-        }
+        replaceListContents(this.eExceptions, newValue);
         break;
       case 'eAnnotations':
-        if (Array.isArray(newValue)) {
-          this.eAnnotations = newValue;
-        }
+        replaceListContents(this.eAnnotations, newValue);
         break;
       case 'ordered':
         this.ordered = newValue === true || newValue === 'true';

--- a/src/runtime/BasicEPackage.ts
+++ b/src/runtime/BasicEPackage.ts
@@ -14,8 +14,7 @@ import { BasicEObject } from './BasicEObject.js';
 import { EAnnotation } from '../EAnnotation.js';
 import { BasicEFactory } from './BasicEFactory.js';
 import { ecoreRegistry } from '../ecore/EcoreRegistry.js';
-import { BasicEList, createIndexedProxy } from '../EList.js';
-import type { EList } from '../EList.js';
+import { BasicEList, EList, createIndexedProxy, createMetamodelEList } from '../EList.js';
 
 /**
  * Containment EList for EPackage.eClassifiers
@@ -272,8 +271,10 @@ export class BasicEPackage extends BasicEObject implements EPackage {
   }
 
   // EObject methods
-  getEAnnotations(): EAnnotation[] {
-    return [];
+  private eAnnotations: EList<EAnnotation> = createMetamodelEList<EAnnotation>(this);
+
+  getEAnnotations(): EList<EAnnotation> {
+    return this.eAnnotations;
   }
 
   getEAnnotation(source: string): EAnnotation | null {

--- a/src/runtime/BasicEParameter.ts
+++ b/src/runtime/BasicEParameter.ts
@@ -15,6 +15,7 @@ import { EGenericType } from '../EGenericType.js';
 import { BasicEObject } from './BasicEObject.js';
 import { EAnnotation } from '../EAnnotation.js';
 import { ecoreRegistry } from '../ecore/EcoreRegistry.js';
+import { EList, createMetamodelEList, replaceListContents } from '../EList.js';
 
 /**
  * Basic EParameter implementation.
@@ -26,7 +27,7 @@ export class BasicEParameter extends BasicEObject implements EParameter {
   private name: string | null = null;
   private eType: EClassifier | null = null;
   private eOperation: EOperation | null = null;
-  private eAnnotations: EAnnotation[] = [];
+  private eAnnotations: EList<EAnnotation> = createMetamodelEList<EAnnotation>(this);
   private eGenericType: EGenericType | null = null;
   private ordered: boolean = true;
   private unique: boolean = true;
@@ -109,7 +110,7 @@ export class BasicEParameter extends BasicEObject implements EParameter {
     this.upperBound = value;
   }
 
-  getEAnnotations(): EAnnotation[] {
+  getEAnnotations(): EList<EAnnotation> {
     return this.eAnnotations;
   }
 
@@ -160,9 +161,7 @@ export class BasicEParameter extends BasicEObject implements EParameter {
         this.eGenericType = newValue;
         break;
       case 'eAnnotations':
-        if (Array.isArray(newValue)) {
-          this.eAnnotations = newValue;
-        }
+        replaceListContents(this.eAnnotations, newValue);
         break;
       case 'ordered':
         this.ordered = newValue === true || newValue === 'true';

--- a/src/runtime/BasicEReference.ts
+++ b/src/runtime/BasicEReference.ts
@@ -11,6 +11,7 @@ import { EClass } from '../EClass.js';
 import { EAttribute } from '../EAttribute.js';
 import { BasicEStructuralFeature } from './BasicEStructuralFeature.js';
 import { ecoreRegistry } from '../ecore/EcoreRegistry.js';
+import { EList, createMetamodelEList, replaceListContents } from '../EList.js';
 
 /**
  * Basic EReference implementation
@@ -19,7 +20,7 @@ export class BasicEReference extends BasicEStructuralFeature implements EReferen
   private containment: boolean = false;
   private resolveProxies: boolean = true;
   private eOpposite: EReference | null = null;
-  private eKeys: EAttribute[] = [];
+  private eKeys: EList<EAttribute> = createMetamodelEList<EAttribute>(this);
 
   isContainment(): boolean {
     return this.containment;
@@ -77,12 +78,12 @@ export class BasicEReference extends BasicEStructuralFeature implements EReferen
     return type as EClass;
   }
 
-  getEKeys(): EAttribute[] {
+  getEKeys(): EList<EAttribute> {
     return this.eKeys;
   }
 
   addEKey(key: EAttribute): void {
-    this.eKeys.push(key);
+    this.eKeys.add(key);
   }
 
   getDefaultValue(): any {
@@ -131,10 +132,7 @@ export class BasicEReference extends BasicEStructuralFeature implements EReferen
         super.eSet(feature, newValue);
         break;
       case 'eKeys':
-        if (Array.isArray(newValue)) {
-          this.eKeys = newValue;
-        }
-        super.eSet(feature, newValue);
+        replaceListContents(this.eKeys, newValue);
         break;
       default:
         super.eSet(feature, newValue);

--- a/src/runtime/BasicEStructuralFeature.ts
+++ b/src/runtime/BasicEStructuralFeature.ts
@@ -16,6 +16,7 @@ import { ecoreRegistry } from '../ecore/EcoreRegistry.js';
 import { EPackageRegistry } from '../EPackage.js';
 import { isInternalEObject } from '../InternalEObject.js';
 import { resolveClassifierInPackage } from './resolveClassifierInPackage.js';
+import { EList, createMetamodelEList, replaceListContents } from '../EList.js';
 
 /**
  * Abstract base class for EAttribute and EReference
@@ -34,7 +35,7 @@ export abstract class BasicEStructuralFeature extends BasicEObject implements ES
   private lowerBound: number = 0;
   private upperBound: number = 1;
   private featureID: number = -1;
-  protected eAnnotations: EAnnotation[] = [];
+  protected eAnnotations: EList<EAnnotation> = createMetamodelEList<EAnnotation>(this);
 
   getName(): string | null {
     return this.name;
@@ -229,7 +230,7 @@ export abstract class BasicEStructuralFeature extends BasicEObject implements ES
   }
 
   // EObject methods
-  getEAnnotations(): EAnnotation[] {
+  getEAnnotations(): EList<EAnnotation> {
     return this.eAnnotations;
   }
 
@@ -327,10 +328,7 @@ export abstract class BasicEStructuralFeature extends BasicEObject implements ES
         super.eSet(feature, newValue);
         break;
       case 'eAnnotations':
-        if (Array.isArray(newValue)) {
-          this.eAnnotations = newValue;
-        }
-        super.eSet(feature, newValue);
+        replaceListContents(this.eAnnotations, newValue);
         break;
       default:
         super.eSet(feature, newValue);

--- a/src/runtime/BasicETypeParameter.ts
+++ b/src/runtime/BasicETypeParameter.ts
@@ -13,6 +13,7 @@ import { EStructuralFeature } from '../EStructuralFeature.js';
 import { BasicEObject } from './BasicEObject.js';
 import { EAnnotation } from '../EAnnotation.js';
 import { ecoreRegistry } from '../ecore/EcoreRegistry.js';
+import { EList, createMetamodelEList, replaceListContents } from '../EList.js';
 
 /**
  * Basic ETypeParameter implementation (#65).
@@ -21,8 +22,8 @@ import { ecoreRegistry } from '../ecore/EcoreRegistry.js';
  */
 export class BasicETypeParameter extends BasicEObject implements ETypeParameter {
   private name: string | null = null;
-  private eBounds: EGenericType[] = [];
-  private eAnnotations: EAnnotation[] = [];
+  private eBounds: EList<EGenericType> = createMetamodelEList<EGenericType>(this);
+  private eAnnotations: EList<EAnnotation> = createMetamodelEList<EAnnotation>(this);
 
   getName(): string | null {
     return this.name;
@@ -32,11 +33,11 @@ export class BasicETypeParameter extends BasicEObject implements ETypeParameter 
     this.name = value;
   }
 
-  getEBounds(): EGenericType[] {
+  getEBounds(): EList<EGenericType> {
     return this.eBounds;
   }
 
-  getEAnnotations(): EAnnotation[] {
+  getEAnnotations(): EList<EAnnotation> {
     return this.eAnnotations;
   }
 
@@ -67,14 +68,10 @@ export class BasicETypeParameter extends BasicEObject implements ETypeParameter 
         this.name = newValue;
         break;
       case 'eBounds':
-        if (Array.isArray(newValue)) {
-          this.eBounds = newValue;
-        }
+        replaceListContents(this.eBounds, newValue);
         break;
       case 'eAnnotations':
-        if (Array.isArray(newValue)) {
-          this.eAnnotations = newValue;
-        }
+        replaceListContents(this.eAnnotations, newValue);
         break;
     }
     super.eSet(feature, newValue);

--- a/src/runtime/BasicResource.ts
+++ b/src/runtime/BasicResource.ts
@@ -10,10 +10,10 @@ import { Resource } from '../Resource.js';
 import { ResourceSet } from '../ResourceSet.js';
 import { URI } from '../URI.js';
 import { EObject } from '../EObject.js';
-import { EList, createResourceContentsEList } from '../EList.js';
 import { Notifier } from '../notify/Notifier.js';
 import { Adapter } from '../notify/Adapter.js';
 import { Notification } from '../notify/Notification.js';
+import { EList, createResourceContentsEList } from '../EList.js';
 
 /**
  * Basic Resource implementation

--- a/src/runtime/BasicResourceSet.ts
+++ b/src/runtime/BasicResourceSet.ts
@@ -12,15 +12,19 @@ import { URI } from '../URI.js';
 import { EObject } from '../EObject.js';
 import { EPackage, EPackageRegistry, requireNsURI } from '../EPackage.js';
 import { BasicResource } from './BasicResource.js';
-import { EList, BasicEList, createIndexedProxy } from '../EList.js';
 import { EClass } from '../EClass.js';
 import { resolveClassifierInPackage } from './resolveClassifierInPackage.js';
+import { BasicEList, EList, createIndexedProxy } from '../EList.js';
 
 /**
  * Basic ResourceSet implementation
  */
 export class BasicResourceSet implements ResourceSet {
-  private resources: Resource[] = [];
+  /**
+   * Not a metamodel list: adding a resource must not invalidate the derived
+   * feature caches, so this uses a plain BasicEList rather than MetamodelEList.
+   */
+  private resources: EList<Resource> = new BasicEList<Resource>();
   private packageRegistry: EPackageRegistry;
   private resourceFactoryRegistry: Resource.FactoryRegistry;
   private uriConverter: URIConverter;
@@ -35,7 +39,7 @@ export class BasicResourceSet implements ResourceSet {
     this.uriConverter = this.createDefaultURIConverter();
   }
 
-  getResources(): Resource[] {
+  getResources(): EList<Resource> {
     return this.resources;
   }
 

--- a/tests/DerivedLists.test.ts
+++ b/tests/DerivedLists.test.ts
@@ -1,0 +1,229 @@
+/**
+ * @fileoverview Tests for EList-returning accessors and derived list caching
+ *
+ * All multi-valued accessors return an EList, matching Java EMF. Accessors that
+ * own their contents are modifiable; derived accessors, which assemble their
+ * result from the class and its supertypes, are read-only and cached until the
+ * metamodel changes.
+ *
+ * @module tests/DerivedLists
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  BasicEClass,
+  BasicEAttribute,
+  BasicEReference,
+  BasicEPackage,
+  BasicEOperation,
+  EcoreDataTypes,
+  isEList,
+  type EClass,
+} from '../src';
+
+function attribute(name: string): BasicEAttribute {
+  const attr = new BasicEAttribute();
+  attr.setName(name);
+  attr.setEType(EcoreDataTypes.EString);
+  return attr;
+}
+
+function reference(name: string, type: EClass, containment = false): BasicEReference {
+  const ref = new BasicEReference();
+  ref.setName(name);
+  ref.setEType(type);
+  ref.setContainment(containment);
+  return ref;
+}
+
+describe('EList-returning accessors', () => {
+  let pkg: BasicEPackage;
+  let base: BasicEClass;
+  let derived: BasicEClass;
+
+  beforeEach(() => {
+    pkg = new BasicEPackage();
+    pkg.setName('p');
+    pkg.setNsURI('http://test.derived');
+
+    base = new BasicEClass();
+    base.setName('Base');
+    base.addFeature(attribute('baseAttr'));
+    pkg.getEClassifiers().add(base);
+
+    derived = new BasicEClass();
+    derived.setName('Derived');
+    derived.getESuperTypes().add(base);
+    derived.addFeature(attribute('ownAttr'));
+    pkg.getEClassifiers().add(derived);
+  });
+
+  describe('owned accessors are modifiable ELists', () => {
+    it('should return an EList from getESuperTypes', () => {
+      expect(isEList(derived.getESuperTypes())).toBe(true);
+      expect(derived.getESuperTypes().size()).toBe(1);
+    });
+
+    it('should let getESuperTypes be modified and take effect', () => {
+      const another = new BasicEClass();
+      another.setName('Another');
+
+      derived.getESuperTypes().add(another);
+
+      expect(derived.getESuperTypes().size()).toBe(2);
+      expect(derived.getEAllSuperTypes().contains(another)).toBe(true);
+    });
+
+    it('should return an EList from getEOperations and accept additions', () => {
+      const op = new BasicEOperation();
+      op.setName('doIt');
+
+      derived.getEOperations().add(op);
+
+      expect(isEList(derived.getEOperations())).toBe(true);
+      expect(derived.getEOperations().size()).toBe(1);
+      expect(derived.getEAllOperations().contains(op)).toBe(true);
+    });
+  });
+
+  describe('derived accessors are read-only', () => {
+    it.each([
+      'getEAllSuperTypes',
+      'getEAllStructuralFeatures',
+      'getEAttributes',
+      'getEAllAttributes',
+      'getEReferences',
+      'getEAllReferences',
+      'getEAllContainments',
+      'getEAllOperations',
+    ])('%s should refuse modification', accessor => {
+      const list = (derived as any)[accessor]();
+
+      expect(isEList(list)).toBe(true);
+      expect(() => list.add(attribute('x'))).toThrow(/derived list and cannot be modified/);
+      expect(() => list.clear()).toThrow(/derived list and cannot be modified/);
+    });
+
+    it('should name the accessor in the error message', () => {
+      expect(() => (derived.getEAllStructuralFeatures() as any).add(attribute('x')))
+        .toThrow(/getEAllStructuralFeatures/);
+    });
+
+    it('should still support reading', () => {
+      const all = derived.getEAllStructuralFeatures();
+
+      expect(all.size()).toBe(2);
+      expect(all.map(f => f.getName())).toEqual(['baseAttr', 'ownAttr']);
+      expect(all[0].getName()).toBe('baseAttr');
+      expect([...all].length).toBe(2);
+    });
+  });
+
+  describe('caching', () => {
+    it('should return the identical list while the metamodel is unchanged', () => {
+      // Java EMF caches derived lists per class, so repeated calls yield the
+      // same list object.
+      expect(derived.getEAllStructuralFeatures()).toBe(derived.getEAllStructuralFeatures());
+      expect(derived.getEAllSuperTypes()).toBe(derived.getEAllSuperTypes());
+    });
+
+    it('should recompute after a feature is added to the class itself', () => {
+      const before = derived.getEAllStructuralFeatures();
+
+      derived.addFeature(attribute('added'));
+      const after = derived.getEAllStructuralFeatures();
+
+      expect(after).not.toBe(before);
+      expect(after.size()).toBe(3);
+      expect(after.map(f => f.getName())).toContain('added');
+    });
+
+    it('should recompute after a feature is added to a supertype', () => {
+      // The invalidation has to reach subclasses, which is what ESuperAdapter
+      // does in Java EMF.
+      expect(derived.getEAllStructuralFeatures().size()).toBe(2);
+
+      base.addFeature(attribute('lateBaseAttr'));
+
+      expect(derived.getEAllStructuralFeatures().size()).toBe(3);
+      expect(derived.getEAllStructuralFeatures().map(f => f.getName())).toContain('lateBaseAttr');
+    });
+
+    it('should recompute through two levels of inheritance', () => {
+      const leaf = new BasicEClass();
+      leaf.setName('Leaf');
+      leaf.getESuperTypes().add(derived);
+      pkg.getEClassifiers().add(leaf);
+
+      expect(leaf.getEAllStructuralFeatures().size()).toBe(2);
+
+      base.addFeature(attribute('grandparentAttr'));
+
+      expect(leaf.getEAllStructuralFeatures().size()).toBe(3);
+    });
+
+    it('should recompute after a supertype is added', () => {
+      const extra = new BasicEClass();
+      extra.setName('Extra');
+      extra.addFeature(attribute('extraAttr'));
+
+      expect(derived.getEAllStructuralFeatures().size()).toBe(2);
+
+      derived.getESuperTypes().add(extra);
+
+      expect(derived.getEAllStructuralFeatures().size()).toBe(3);
+    });
+
+    it('should recompute after a feature is removed', () => {
+      const doomed = attribute('doomed');
+      derived.addFeature(doomed);
+      expect(derived.getEAllStructuralFeatures().size()).toBe(3);
+
+      derived.getEStructuralFeatures().remove(doomed);
+
+      expect(derived.getEAllStructuralFeatures().size()).toBe(2);
+    });
+
+    it('should keep attribute and reference views in sync', () => {
+      expect(derived.getEAllAttributes().size()).toBe(2);
+      expect(derived.getEAllReferences().size()).toBe(0);
+
+      derived.addFeature(reference('ref', base, true));
+
+      expect(derived.getEAllReferences().size()).toBe(1);
+      expect(derived.getEAllContainments().size()).toBe(1);
+      expect(derived.getEAllAttributes().size()).toBe(2);
+    });
+  });
+
+  describe('eSet on multi-valued features', () => {
+    it('should accept a plain array', () => {
+      const replacement = [attribute('r1'), attribute('r2')];
+      const feature = derived.eClass().getEStructuralFeature('eStructuralFeatures')!;
+
+      derived.eSet(feature, replacement);
+
+      expect(derived.getEStructuralFeatures().map(f => f.getName())).toEqual(['r1', 'r2']);
+    });
+
+    it('should accept an EList', () => {
+      // Before the unification this silently did nothing, because the eSet
+      // implementations checked Array.isArray().
+      const source = new BasicEClass();
+      source.setName('Source');
+      source.addFeature(attribute('fromSource'));
+      const feature = derived.eClass().getEStructuralFeature('eStructuralFeatures')!;
+
+      derived.eSet(feature, source.getEStructuralFeatures());
+
+      expect(derived.getEStructuralFeatures().map(f => f.getName())).toEqual(['fromSource']);
+    });
+
+    it('should reflect eSet in the derived lists', () => {
+      const feature = derived.eClass().getEStructuralFeature('eStructuralFeatures')!;
+
+      derived.eSet(feature, [attribute('only')]);
+
+      expect(derived.getEAllStructuralFeatures().map(f => f.getName())).toEqual(['baseAttr', 'only']);
+    });
+  });
+});

--- a/tests/EList.test.ts
+++ b/tests/EList.test.ts
@@ -38,6 +38,7 @@ import {
   isEList,
   BasicEList,
   createIndexedProxy,
+  createUnmodifiableEList,
 } from '../src';
 
 /**
@@ -924,6 +925,82 @@ describe('EList', () => {
       const list = new BasicEList<string>();
 
       expect(createIndexedProxy(list)).toBe(list);
+    });
+  });
+
+  /**
+   * Read-only lists for derived accessors.
+   *
+   * Mirrors EcoreEList.UnmodifiableEList in Java EMF, which throws
+   * UnsupportedOperationException from every mutating method. Writing into a
+   * derived result cannot have an effect, so it must not appear to succeed.
+   */
+  describe('UnmodifiableEList', () => {
+    const make = () => createUnmodifiableEList(['a', 'b'], 'getEAllStructuralFeatures');
+
+    it('should support all read operations', () => {
+      const list = make();
+
+      expect(list.size()).toBe(2);
+      expect(list.length).toBe(2);
+      expect(list.get(0)).toBe('a');
+      expect(list[1]).toBe('b');
+      expect(list.indexOf('b')).toBe(1);
+      expect(list.contains('a')).toBe(true);
+      expect(list.map(v => v.toUpperCase())).toEqual(['A', 'B']);
+      expect([...list]).toEqual(['a', 'b']);
+      expect(Array.from(list)).toEqual(['a', 'b']);
+      expect(list.toArray()).toEqual(['a', 'b']);
+      expect(JSON.stringify(list)).toBe('["a","b"]');
+    });
+
+    it.each([
+      ['add', (l: any) => l.add('c')],
+      ['addAt', (l: any) => l.addAt(0, 'c')],
+      ['addAll', (l: any) => l.addAll(['c'])],
+      ['addAllAt', (l: any) => l.addAllAt(0, ['c'])],
+      ['set', (l: any) => l.set(0, 'c')],
+      ['remove', (l: any) => l.remove('a')],
+      ['removeAt', (l: any) => l.removeAt(0)],
+      ['clear', (l: any) => l.clear()],
+      ['move', (l: any) => l.move(1, 0)],
+      ['push', (l: any) => l.push('c')],
+      ['pop', (l: any) => l.pop()],
+      ['shift', (l: any) => l.shift()],
+      ['unshift', (l: any) => l.unshift('c')],
+      ['splice', (l: any) => l.splice(0, 1)],
+      ['sort', (l: any) => l.sort()],
+      ['reverse', (l: any) => l.reverse()],
+      ['index assignment', (l: any) => { l[0] = 'c'; }],
+      ['length assignment', (l: any) => { l.length = 0; }],
+    ])('should refuse %s', (_name, mutate) => {
+      const list = make();
+
+      expect(() => mutate(list)).toThrow(/derived list and cannot be modified/);
+      expect(list.toArray()).toEqual(['a', 'b']);
+    });
+
+    it('should name the accessor in the error message', () => {
+      const list = make();
+
+      expect(() => (list as any).add('c')).toThrow(/getEAllStructuralFeatures/);
+    });
+
+    it('should use the given array as backing store without copying', () => {
+      // Java EMF wraps the computed result rather than copying it, which is what
+      // makes the wrapper cheap.
+      const data = ['a'];
+      const list = createUnmodifiableEList(data, 'getEAllSuperTypes');
+
+      data.push('b');
+
+      expect(list.size()).toBe(2);
+    });
+
+    it('should return a modifiable copy from toArray', () => {
+      const copy = make().toArray();
+
+      expect(() => copy.push('c')).not.toThrow();
     });
   });
 });


### PR DESCRIPTION
Completes point 1 of #68: every multi-valued accessor returns `EList<T>` instead of `T[]`. No accessor in the API returns a plain array any more, which is what Java EMF does throughout.

`0.1.1-next.17` shipped the additive groundwork for this (index access, `toJSON`, the missing array methods). This is the breaking half, hence `0.2.0-next.1`.

One commit per step so they can be reviewed independently.

## Two kinds of list, as in Java EMF

| | example | writable |
|---|---|---|
| **Owned** — holds the contents | `getEStructuralFeatures()`, `getEOperations()`, `getESuperTypes()`, `getEParameters()`, `getELiterals()` | yes |
| **Derived** — assembled from the class and its supertypes | `getEAll*()`, `getEAttributes()`, `getEReferences()`, `getEAllContainments()` | **no** |

Writing into a derived list could never have an effect, so it throws instead of failing silently:

```
Cannot call add() on the result of getEAllStructuralFeatures():
it is a derived list and cannot be modified.
Modify the owning list instead (e.g. getEStructuralFeatures()).
```

This mirrors `EcoreEList.UnmodifiableEList`, whose mutating methods throw `UnsupportedOperationException`. The wrapper uses the computed array as its backing store rather than copying it, the way `new EAllStructuralFeaturesList(result)` does in `EClassImpl`.

## Derived lists are cached

Measured on a five-level hierarchy with 50 features:

```
getEAllStructuralFeatures()              3.4 µs  ->  0.31 µs   (11x)
getEAllStructuralFeatures() === same()   false   ->  true
```

Object identity across calls now matches Java EMF, where repeated calls return the same list while the model is unchanged.

Java invalidates per class through `ESuperAdapter`, which keeps a reverse registry of subclasses and pushes invalidation downwards. This uses a single global revision counter instead: a cached list is valid exactly while the counter has not moved. Same correctness, an O(1) check, and no registry with lifecycle questions (who unregisters a class removed from the model?). The trade-off is that a change to one class invalidates all cached lists rather than only the affected ones — that suits the usual lifecycle of loading a model and then reading it many times, and is never worse than the previous behaviour of recomputing on every call.

Invalidation is transitive: adding a feature to a grandparent class refreshes its descendants' lists. Covered by tests across two levels of inheritance, since that is where a cache goes quietly wrong.

## Affected accessors

21 signatures across 10 interfaces: `EClass` (10), `EOperation` (`getEParameters`, `getEExceptions`), `EAnnotation` (`getContents`, `getReferences`), `EModelElement` (`getEAnnotations`, which touches nine `Basic*` classes), `EEnum` (`getELiterals`), `EClassifier` (`getETypeParameters`), `ETypeParameter` (`getEBounds`), `EGenericType` (`getETypeArguments`), `EReference` (`getEKeys`), `ResourceSet` (`getResources`).

Field, getter and signature had to change together per accessor: leaving a getter on arrays while its field became an `EList` would have made `getESuperTypes().push(x)` silently ineffective.

## Consumer impact

Smaller than the label suggests, because `EList` already carries the array API. All of this keeps working unchanged:

```ts
list.length      list[0]      list.map(fn) / filter / find / some / every / reduce
list.push(x)     list.sort()  [...list]    const [a] = list    for (const x of list)
JSON.stringify(list)   // -> [...]
```

Two things break, both documented in [docs/collections.md](../blob/feat/unify-accessors-on-elist/docs/collections.md):

- **`Array.isArray(result)` is `false`.** The normalizing idiom `Array.isArray(v) ? v : [v]` takes the wrong branch and would treat a list as a single value. Exported `isListValue(v)` / `toArray(v)` replace it. `Array.isArray` staying false is deliberate: a list that guarantees notifications cannot be an array, since `Array` exposes the `length` setter and raw index assignment, which bypass every interceptor — and `Symbol.species` would make `map()`/`filter()` construct an `EList` with an array length as its constructor argument.
- **Passing a result where a real array is required** needs `Array.from(result)`.

**Not included:** two pre-existing issues found while analysing this, each deserving its own fix — the dead branch in `BasicEObject.eSet` (`eSet(containment-many, [...])` never sets containers, because the outer `'eSetContainer' in newValue` check cannot pass for an array), and the missing coupling of `getESuperTypes()` to `eGenericSuperTypes`, which Java models as a `DelegatingEcoreEList` view so both stay in sync.

## Also in here

- `getEAnnotations()` on `BasicEPackage`, `BasicEFactory` and `BasicEAnnotation` returned a hardcoded `[]`, so annotations on packages, factories and annotations themselves were unreachable — the same stub pattern #66 uncovered on `BasicEOperation`. Backed by a real list now.
- `filter`/`find`/`findIndex`/`some`/`every` accept a predicate returning `unknown` rather than `boolean`, matching how TypeScript types `Array.prototype`. Callbacks of the form `x && y` type-check again.
- CI ran `npm test`, which is `vitest` in watch mode and only terminated because vitest detects CI. It now calls `test:run` explicitly, so the job cannot hang if that detection changes, and adds the `github-actions` reporter to annotate failing tests in the diff.

## Verification

- `tsc` clean, **461 tests passing** in 20 files. Baseline on `snapshot`: 446 in 19 — the 15 additional tests are the EEnum work from `0.1.1-next.18`, which this branch is rebased onto.
- **No existing test needed adjusting.** The additive groundwork from `next.17` is why.
- 45 new tests: `tests/DerivedLists.test.ts` (owned vs derived, caching, transitive invalidation, `eSet` with both array and EList) and additions to `tests/EList.test.ts` (`UnmodifiableEList` refusing all 18 mutation paths, `Array.isArray() === false` pinned as contract).
- A consumer-shaped smoke test confirmed the common access patterns — index, `.length`, `for...of`, `map`/`find`, spread — still work on a loaded `.ecore`.
- Rebased onto `snapshot`; the only conflicts were the changelog section and the version number, both from `0.1.1-next.18`. The EEnum fix works unchanged against the new `EList`-returning `getELiterals()`.
